### PR TITLE
feat(pools,collections): q search, column filters, date sorting

### DIFF
--- a/bsimvis/app/routes/_list_query.py
+++ b/bsimvis/app/routes/_list_query.py
@@ -1,0 +1,114 @@
+"""Shared in-memory filter/sort/paginate helpers for the small registry list
+endpoints (collections, pools). These registries hold at most ~1k items, so we
+hydrate all, then filter/sort/paginate in Python — no Redis secondary index.
+
+ponytail: in-memory is correct at this cardinality. If pool/collection count
+grows well past 1k and per-request hydration gets hot, add ZSET date indexes
+and page-before-hydrate.
+
+Each request-reading helper takes an optional `args` mapping (defaults to the
+Flask request args) so the logic is testable without a request context.
+"""
+
+
+def _args(args):
+    if args is not None:
+        return args
+    from flask import request
+
+    return request.args
+
+
+def keywords(args=None):
+    """Whitespace-split lowercased tokens from the `q` query param."""
+    q = _args(args).get("q", "").lower().strip()
+    return [k for k in q.split() if k]
+
+
+def matches_keywords(kws, *fields):
+    """True if every keyword is a substring of at least one of `fields`."""
+    hay = " ".join(str(f).lower() for f in fields if f is not None)
+    return all(kw in hay for kw in kws)
+
+
+def num_range(field, args=None):
+    """(min, max) floats for `field` from ?min_<field>/?max_<field>, or None ends.
+    Returns None if neither bound supplied."""
+    a = _args(args)
+    lo = a.get(f"min_{field}")
+    hi = a.get(f"max_{field}")
+    if lo is None and hi is None:
+        return None
+    try:
+        lo_f = float(lo) if lo not in (None, "") else float("-inf")
+        hi_f = float(hi) if hi not in (None, "") else float("inf")
+    except ValueError:
+        return None
+    return (lo_f, hi_f)
+
+
+def in_range(val, rng):
+    if rng is None:
+        return True
+    try:
+        v = float(val)
+    except (ValueError, TypeError):
+        return False
+    return rng[0] <= v <= rng[1]
+
+
+def sort_and_paginate(
+    items, offset, limit, default_key, default_reverse, key_fns, args=None
+):
+    """Sort `items` (list of dicts) by ?sort_by/?sort_order then slice.
+
+    key_fns: {field_name: callable(item)->comparable}. `sort_by` must be a key in
+    key_fns to take effect, else falls back to default_key.
+    Returns (page, total).
+    """
+    a = _args(args)
+    total = len(items)
+    sort_by = a.get("sort_by") or default_key
+    order = a.get("sort_order")
+    if order:
+        reverse = order.lower() == "desc"
+    else:
+        reverse = default_reverse
+
+    keyfn = key_fns.get(sort_by, key_fns.get(default_key))
+    if keyfn:
+        items = sorted(items, key=keyfn, reverse=reverse)
+    return items[offset : offset + limit], total
+
+
+def _selfcheck():
+    # keywords + matches
+    assert keywords({"q": " Foo  BAR "}) == ["foo", "bar"]
+    assert matches_keywords(["ab"], "xxAByy", None)
+    assert not matches_keywords(["zz"], "ab")
+
+    # num_range + in_range
+    assert num_range("files", {}) is None
+    assert num_range("files", {"min_files": "10", "max_files": "20"}) == (10.0, 20.0)
+    r = num_range("files", {"min_files": "10"})
+    assert r == (10.0, float("inf"))
+    assert in_range(15, r) and not in_range(5, r)
+    assert in_range(1, None)  # no range = pass
+    assert not in_range("x", (0, 5))  # non-numeric fails a real range
+
+    # sort desc + paginate
+    items = [{"n": v} for v in [3, 1, 2, 5, 4]]
+    keyf = {"n": lambda d: d["n"]}
+    page, total = sort_and_paginate(
+        items, 0, 2, "n", False, keyf, {"sort_by": "n", "sort_order": "desc"}
+    )
+    assert total == 5
+    assert [d["n"] for d in page] == [5, 4], page
+    # offset + default order
+    page2, _ = sort_and_paginate(items, 2, 2, "n", False, keyf, {})
+    assert [d["n"] for d in page2] == [3, 4], page2
+    print("ok")
+
+
+if __name__ == "__main__":
+    _selfcheck()

--- a/bsimvis/app/routes/pools.py
+++ b/bsimvis/app/routes/pools.py
@@ -1,6 +1,7 @@
 from flask import request, jsonify
 from bsimvis.app.services.pool_service import pool_service
 from bsimvis.app.services.job_service import JobService, JobType
+from bsimvis.app.routes import _list_query as lq
 
 job_service = JobService()
 
@@ -76,9 +77,65 @@ def get_pool(pool_id):
 
 
 def list_pools():
+    """Lists pools with keyword search (q), specific-field filters, and sorting.
+
+    Params: q, name, sync_status, collection (membership), sort_by, sort_order,
+    offset, limit, refresh_sync, min_/max_ ranges on created_at/last_built_at
+    and the count fields.
+    """
+    try:
+        offset = int(request.args.get("offset", 0))
+        limit = int(request.args.get("limit", 100))
+    except ValueError:
+        return {"error": "offset and limit must be integers"}, 400
+
     collection = request.args.get("collection")
-    pools = pool_service.list_pools(collection=collection)
-    return {"pools": pools}
+    refresh_sync = request.args.get("refresh_sync") in ("1", "true", "True")
+    pools = pool_service.list_pools(collection=collection, refresh_sync=refresh_sync)
+
+    count_fields = [
+        "total_func_similarities",
+        "total_func_clusters",
+        "total_file_similarities",
+        "total_file_clusters",
+    ]
+
+    # Filter: q over name/id/collections/sync_status, plus specific-field filters
+    kws = lq.keywords()
+    name_filter = request.args.get("name", "").lower().strip()
+    id_filter = request.args.get("id", "").lower().strip()
+    status_filter = request.args.get("sync_status", "").lower().strip()
+    ranges = {f: lq.num_range(f) for f in ["created_at", "last_built_at"] + count_fields}
+
+    def keep(p):
+        colls = " ".join(p.get("collections", []))
+        if not lq.matches_keywords(
+            kws, p.get("name"), p.get("id"), colls, p.get("sync_status")
+        ):
+            return False
+        if name_filter and name_filter not in str(p.get("name", "")).lower():
+            return False
+        if id_filter and id_filter not in str(p.get("id", "")).lower():
+            return False
+        if status_filter and status_filter != str(p.get("sync_status", "")).lower():
+            return False
+        return all(lq.in_range(p.get(f, 0), rng) for f, rng in ranges.items())
+
+    pools = [p for p in pools if keep(p)]
+
+    key_fns = {
+        "name": lambda p: str(p.get("name", "")).lower(),
+        "id": lambda p: str(p.get("id", "")).lower(),
+        "sync_status": lambda p: str(p.get("sync_status", "")).lower(),
+        "created_at": lambda p: int(p.get("created_at", 0) or 0),
+        "last_built_at": lambda p: int(p.get("last_built_at", 0) or 0),
+    }
+    key_fns.update({f: (lambda f: lambda p: int(p.get(f, 0) or 0))(f) for f in count_fields})
+
+    page, total = lq.sort_and_paginate(
+        pools, offset, limit, "created_at", True, key_fns
+    )
+    return {"pools": page, "total": total, "offset": offset, "limit": limit}
 
 
 def delete_pool(pool_id):

--- a/bsimvis/app/routes/search_collection.py
+++ b/bsimvis/app/routes/search_collection.py
@@ -3,6 +3,7 @@ import logging
 from flask import request
 from bsimvis.app.services.redis_client import get_redis
 from bsimvis.app.services.index_service import parse_timestamp
+from bsimvis.app.routes import _list_query as lq
 
 
 def search_collections():
@@ -15,7 +16,6 @@ def search_collections():
         except ValueError:
             return {"error": "offset and limit must be integers"}, 400
 
-        q = request.args.get("q", "").lower().strip()
         format_arg = request.args.get("format")
         if format_arg in ("csv", "json"):
             offset = 0
@@ -28,17 +28,9 @@ def search_collections():
             ]
         )
 
-        if q:
-            keywords = [k for k in q.split() if k]
-            filtered_names = []
-            for name in collection_names:
-                name_lower = name.lower()
-                if all(kw in name_lower for kw in keywords):
-                    filtered_names.append(name)
-            collection_names = filtered_names
-
-        total = len(collection_names)
-        page_names = collection_names[offset : offset + limit]
+        # Hydrate ALL collection metas up front so we can filter/sort/paginate
+        # in-memory (bounded to hundreds/low-thousands of collections).
+        page_names = collection_names
 
         # 1. Fetch metadata hashes first
         pipe = r.pipeline(transaction=False)
@@ -121,6 +113,37 @@ def search_collections():
                     "last_updated": int(meta_decoded.get("last_updated", 0)),
                 }
             )
+
+        # 5. Filter (q over name, plus specific-field filters), sort, paginate
+        kws = lq.keywords()
+        name_filter = request.args.get("name", "").lower().strip()
+        ranges = {
+            "total_files": lq.num_range("files"),
+            "total_functions": lq.num_range("functions"),
+            "total_batches": lq.num_range("batches"),
+            "last_updated": lq.num_range("last_updated"),
+        }
+        results = [
+            c
+            for c in results
+            if lq.matches_keywords(kws, c["name"])
+            and (not name_filter or name_filter in c["name"].lower())
+            and all(lq.in_range(c[f], rng) for f, rng in ranges.items())
+        ]
+        results, total = lq.sort_and_paginate(
+            results,
+            offset,
+            limit,
+            default_key="name",
+            default_reverse=False,
+            key_fns={
+                "name": lambda c: c["name"].lower(),
+                "total_files": lambda c: c["total_files"],
+                "total_functions": lambda c: c["total_functions"],
+                "total_batches": lambda c: c["total_batches"],
+                "last_updated": lambda c: c["last_updated"],
+            },
+        )
 
         response_data = {
             "collections": results,

--- a/bsimvis/app/services/bin_sim_service.py
+++ b/bsimvis/app/services/bin_sim_service.py
@@ -257,7 +257,8 @@ class BinSimService:
 
         def pick_cluster_label(fid_a, fid_b):
             """Best function cluster label for a matched pair: prefer a cluster both
-            share, else any cluster either belongs to; tie-break on tightest cohesion."""
+            share, else any cluster either belongs to; tie-break on tightest cohesion.
+            """
             la = fid_clusters.get(fid_a, set())
             lb = fid_clusters.get(fid_b, set())
             shared = la & lb
@@ -448,17 +449,21 @@ class BinSimService:
                     rarity = get_col_rarity(best_label)
                     diff_matched.append(
                         {
-                            "cluster_id": best_cluster.get("cluster_id", "")
-                            if best_cluster
-                            else "",
-                            "cluster_uuid": best_cluster.get("cluster_uuid", "")
-                            if best_cluster
-                            else "",
-                            "cluster_name": best_cluster.get(
-                                "cluster_name", "Matched Functions"
-                            )
-                            if best_cluster
-                            else "Matched Functions",
+                            "cluster_id": (
+                                best_cluster.get("cluster_id", "")
+                                if best_cluster
+                                else ""
+                            ),
+                            "cluster_uuid": (
+                                best_cluster.get("cluster_uuid", "")
+                                if best_cluster
+                                else ""
+                            ),
+                            "cluster_name": (
+                                best_cluster.get("cluster_name", "Matched Functions")
+                                if best_cluster
+                                else "Matched Functions"
+                            ),
                             "cohesion": score,
                             "sim_rarity": rarity,
                             "collection_rarity": rarity,
@@ -494,15 +499,26 @@ class BinSimService:
                 if f_features <= 0:
                     f_features = 1.0
 
-                rarity = get_col_rarity(_pick_label(fid_clusters.get(fid, set())))
+                cids = fid_clusters.get(fid, set())
+                best_label = _pick_label(cids)
+                best_cluster = cluster_meta.get(best_label) if best_label else None
+                rarity = get_col_rarity(best_label)
                 unique_to_a.append(
                     {
                         "func_id": fid,
                         "funcs": [fid],
-                        "is_clustered": False,
-                        "cluster_id": "",
-                        "cluster_uuid": "",
-                        "cluster_name": "Unclustered",
+                        "is_clustered": best_cluster is not None,
+                        "cluster_id": (
+                            best_cluster.get("cluster_id", "") if best_cluster else ""
+                        ),
+                        "cluster_uuid": (
+                            best_cluster.get("cluster_uuid", "") if best_cluster else ""
+                        ),
+                        "cluster_name": (
+                            best_cluster.get("cluster_name", "Unclustered")
+                            if best_cluster
+                            else "Unclustered"
+                        ),
                         "cohesion": 0.0,
                         "sim_rarity": rarity,
                         "collection_rarity": rarity,
@@ -521,15 +537,26 @@ class BinSimService:
                 if f_features <= 0:
                     f_features = 1.0
 
-                rarity = get_col_rarity(_pick_label(fid_clusters.get(fid, set())))
+                cids = fid_clusters.get(fid, set())
+                best_label = _pick_label(cids)
+                best_cluster = cluster_meta.get(best_label) if best_label else None
+                rarity = get_col_rarity(best_label)
                 unique_to_b.append(
                     {
                         "func_id": fid,
                         "funcs": [fid],
-                        "is_clustered": False,
-                        "cluster_id": "",
-                        "cluster_uuid": "",
-                        "cluster_name": "Unclustered",
+                        "is_clustered": best_cluster is not None,
+                        "cluster_id": (
+                            best_cluster.get("cluster_id", "") if best_cluster else ""
+                        ),
+                        "cluster_uuid": (
+                            best_cluster.get("cluster_uuid", "") if best_cluster else ""
+                        ),
+                        "cluster_name": (
+                            best_cluster.get("cluster_name", "Unclustered")
+                            if best_cluster
+                            else "Unclustered"
+                        ),
                         "cohesion": 0.0,
                         "sim_rarity": rarity,
                         "collection_rarity": rarity,

--- a/bsimvis/app/services/collection_config.py
+++ b/bsimvis/app/services/collection_config.py
@@ -1,0 +1,46 @@
+"""Collection-sticky similarity parameters.
+
+min_features / min_score are locked per collection on first sim build and read
+back everywhere after — so the BSim-vs-hash split (and therefore the canonical
+file-similarity score) is stable regardless of what later jobs pass. The API is
+unchanged: a request value only *initializes* the collection; it is ignored once
+the collection is locked.
+"""
+
+from bsimvis.app.services.redis_client import get_redis
+from bsimvis.app.services.config_service import config_service
+
+_META = "global:collection:{coll}:meta"
+
+
+def _coerce(value, default):
+    """Return value as the same type as default (Redis hashes store strings)."""
+    if isinstance(default, bool):
+        return str(value).lower() in ("1", "true")
+    if isinstance(default, int):
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return default
+    if isinstance(default, float):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+    return value
+
+
+def get_collection_param(collection, name, default=None):
+    v = get_redis().hget(_META.format(coll=collection), name)
+    if v is None:
+        return default
+    return _coerce(v.decode() if isinstance(v, bytes) else v, default)
+
+
+def resolve_and_lock(collection, name, requested):
+    """Lock the param on first call (requested value, else config default), then
+    always return the locked value. `similarity.<name>` supplies the default."""
+    default = config_service.get(f"similarity.{name}", 0)
+    value = requested if requested is not None else default
+    get_redis().hsetnx(_META.format(coll=collection), name, value)
+    return get_collection_param(collection, name, default)

--- a/bsimvis/app/services/ghidra_service.py
+++ b/bsimvis/app/services/ghidra_service.py
@@ -79,8 +79,7 @@ class GhidraService:
             parts = []
             for instr in listing.getInstructions(func.getBody(), True):
                 ops = ",".join(
-                    str(instr.getOperandType(i))
-                    for i in range(instr.getNumOperands())
+                    str(instr.getOperandType(i)) for i in range(instr.getNumOperands())
                 )
                 parts.append(f"{instr.getMnemonicString()}|{ops}")
             if not parts:

--- a/bsimvis/app/services/pool_service.py
+++ b/bsimvis/app/services/pool_service.py
@@ -146,7 +146,7 @@ class PoolService:
 
         return meta
 
-    def list_pools(self, collection=None):
+    def list_pools(self, collection=None, refresh_sync=False):
         r = self.r
         if collection:
             pool_ids = [
@@ -161,8 +161,13 @@ class PoolService:
 
         pools = []
         for pid in pool_ids:
-            # Dynamically verify sync status on list to show accurate state
-            self.check_sync_status(pid)
+            # ponytail: refresh_sync recomputes live sync state per pool (extra
+            # per-collection scans + a 2nd get_pool). Off by default so the list
+            # stays cheap at ~1k pools; sync_status is read from cached meta.
+            # Upgrade path if this ever gets hot: pipeline get_pool reads / ZSET
+            # date index + page-before-hydrate.
+            if refresh_sync:
+                self.check_sync_status(pid)
             meta = self.get_pool(pid)
             if meta:
                 meta["id"] = pid

--- a/bsimvis/app/services/similarity_service.py
+++ b/bsimvis/app/services/similarity_service.py
@@ -1379,7 +1379,9 @@ class SimilarityService:
         start_time = time.time()
         chunk_size = 100
         total_sims = 0
-        pool_small_fids = []  # below min_features -> exact FunctionID-hash match instead
+        pool_small_fids = (
+            []
+        )  # below min_features -> exact FunctionID-hash match instead
         for i in range(0, total, chunk_size):
             chunk = all_function_ids[i : i + chunk_size]
 
@@ -1663,7 +1665,9 @@ class SimilarityService:
         start_time = time.time()
         chunk_size = 5
         total_sims = 0
-        pool_small_fids = []  # below min_features -> exact FunctionID-hash match instead
+        pool_small_fids = (
+            []
+        )  # below min_features -> exact FunctionID-hash match instead
         for i in range(0, total, chunk_size):
             chunk = all_function_ids[i : i + chunk_size]
 
@@ -1985,7 +1989,8 @@ class SimilarityService:
 
         def pick_cluster(full_a, full_b):
             """Best function cluster for a matched pair (mirrors bin_sim_service):
-            prefer a cluster both share, else any either belongs to; tightest cohesion wins."""
+            prefer a cluster both share, else any either belongs to; tightest cohesion wins.
+            """
             la = fid_to_cids.get(full_a, set())
             lb = fid_to_cids.get(full_b, set())
             shared = la & lb
@@ -2152,17 +2157,21 @@ class SimilarityService:
                     best_cluster = pick_cluster(full_a, full_b)
                     diff_matched.append(
                         {
-                            "cluster_id": best_cluster.get("cluster_id", "")
-                            if best_cluster
-                            else "",
-                            "cluster_uuid": best_cluster.get("cluster_uuid", "")
-                            if best_cluster
-                            else "",
-                            "cluster_name": best_cluster.get(
-                                "cluster_name", "Matched Functions"
-                            )
-                            if best_cluster
-                            else "Matched Functions",
+                            "cluster_id": (
+                                best_cluster.get("cluster_id", "")
+                                if best_cluster
+                                else ""
+                            ),
+                            "cluster_uuid": (
+                                best_cluster.get("cluster_uuid", "")
+                                if best_cluster
+                                else ""
+                            ),
+                            "cluster_name": (
+                                best_cluster.get("cluster_name", "Matched Functions")
+                                if best_cluster
+                                else "Matched Functions"
+                            ),
                             "cohesion": score,
                             "sim_rarity": 1.0,
                             "collection_rarity": 1.0,
@@ -2199,14 +2208,36 @@ class SimilarityService:
                 if f_features <= 0:
                     f_features = 1.0
 
+                full_fid = (
+                    fid if fid.startswith(f"{coll_a}:func:") else f"{coll_a}:func:{fid}"
+                )
+                best_cluster = None
+                if full_fid in fid_to_cids:
+                    best = None
+                    best_coh = -1.0
+                    for cid in fid_to_cids[full_fid]:
+                        meta = cluster_meta.get(cid)
+                        if meta and float(meta.get("cohesion_score", 0.0)) > best_coh:
+                            best_coh = float(meta.get("cohesion_score", 0.0))
+                            best = meta
+                    best_cluster = best
+
                 unique_to_a.append(
                     {
                         "func_id": fid,
                         "funcs": [fid],
-                        "is_clustered": False,
-                        "cluster_id": "",
-                        "cluster_uuid": "",
-                        "cluster_name": "Unclustered",
+                        "is_clustered": best_cluster is not None,
+                        "cluster_id": (
+                            best_cluster.get("cluster_id", "") if best_cluster else ""
+                        ),
+                        "cluster_uuid": (
+                            best_cluster.get("cluster_uuid", "") if best_cluster else ""
+                        ),
+                        "cluster_name": (
+                            best_cluster.get("cluster_name", "Unclustered")
+                            if best_cluster
+                            else "Unclustered"
+                        ),
                         "cohesion": 0.0,
                         "sim_rarity": 1.0,
                         "collection_rarity": 1.0,
@@ -2225,14 +2256,36 @@ class SimilarityService:
                 if f_features <= 0:
                     f_features = 1.0
 
+                full_fid = (
+                    fid if fid.startswith(f"{coll_b}:func:") else f"{coll_b}:func:{fid}"
+                )
+                best_cluster = None
+                if full_fid in fid_to_cids:
+                    best = None
+                    best_coh = -1.0
+                    for cid in fid_to_cids[full_fid]:
+                        meta = cluster_meta.get(cid)
+                        if meta and float(meta.get("cohesion_score", 0.0)) > best_coh:
+                            best_coh = float(meta.get("cohesion_score", 0.0))
+                            best = meta
+                    best_cluster = best
+
                 unique_to_b.append(
                     {
                         "func_id": fid,
                         "funcs": [fid],
-                        "is_clustered": False,
-                        "cluster_id": "",
-                        "cluster_uuid": "",
-                        "cluster_name": "Unclustered",
+                        "is_clustered": best_cluster is not None,
+                        "cluster_id": (
+                            best_cluster.get("cluster_id", "") if best_cluster else ""
+                        ),
+                        "cluster_uuid": (
+                            best_cluster.get("cluster_uuid", "") if best_cluster else ""
+                        ),
+                        "cluster_name": (
+                            best_cluster.get("cluster_name", "Unclustered")
+                            if best_cluster
+                            else "Unclustered"
+                        ),
                         "cohesion": 0.0,
                         "sim_rarity": 1.0,
                         "collection_rarity": 1.0,

--- a/bsimvis/app/services/similarity_service.py
+++ b/bsimvis/app/services/similarity_service.py
@@ -97,16 +97,24 @@ class SimilarityService:
         start_time = time.time()
         chunk_size = 100
         total_sims = 0
+        last_t, last_done, last_sims = start_time, 0, 0
 
         for i in range(0, total, chunk_size):
             chunk = function_ids[i : i + chunk_size]
 
             # 1. Update Progress & Metrics
             if job_service and job_id:
-                elapsed = time.time() - start_time
+                now = time.time()
+                elapsed = now - start_time
                 done = i
                 speed = done / elapsed if elapsed > 0 else 0
                 sim_speed = total_sims / elapsed if elapsed > 0 else 0
+                # Instantaneous speed over the last chunk (isolates real slowdowns
+                # from the cumulative average, which lags after one slow chunk)
+                d_t = now - last_t
+                cur_speed = (done - last_done) / d_t if d_t > 0 else 0
+                cur_sim_speed = (total_sims - last_sims) / d_t if d_t > 0 else 0
+                last_t, last_done, last_sims = now, done, total_sims
                 remaining = total - done
                 eta = remaining / speed if speed > 0 else 0
 
@@ -114,7 +122,7 @@ class SimilarityService:
                 job_service.update_progress(
                     job_id,
                     pct,
-                    f"Building similarities: {i}/{total} ({speed:.1f} fn/s, {sim_speed:.1f} sim/s, ETA: {int(eta)}s)",
+                    f"Building similarities: {i}/{total} ({speed:.1f} fn/s, {sim_speed:.1f} sim/s, cur {cur_speed:.1f} fn/s, {cur_sim_speed:.1f} sim/s, ETA: {int(eta)}s)",
                 )
 
                 # Store metrics in job hash for global visibility
@@ -1379,6 +1387,7 @@ class SimilarityService:
         start_time = time.time()
         chunk_size = 100
         total_sims = 0
+        last_t, last_done, last_sims = start_time, 0, 0
         pool_small_fids = (
             []
         )  # below min_features -> exact FunctionID-hash match instead
@@ -1387,14 +1396,19 @@ class SimilarityService:
 
             # Update Progress
             if job_service and job_id:
-                elapsed = time.time() - start_time
+                now = time.time()
+                elapsed = now - start_time
                 done = i
                 speed = done / elapsed if elapsed > 0 else 0
                 sim_speed = total_sims / elapsed if elapsed > 0 else 0
+                d_t = now - last_t
+                cur_speed = (done - last_done) / d_t if d_t > 0 else 0
+                cur_sim_speed = (total_sims - last_sims) / d_t if d_t > 0 else 0
+                last_t, last_done, last_sims = now, done, total_sims
                 job_service.update_progress(
                     job_id,
                     int(done / total * 100),
-                    f"Building pool: {done}/{total} functions ({speed:.1f} fn/s, {sim_speed:.1f} sim/s)",
+                    f"Building pool: {done}/{total} functions ({speed:.1f} fn/s, {sim_speed:.1f} sim/s, cur {cur_speed:.1f} fn/s, {cur_sim_speed:.1f} sim/s)",
                 )
 
             # Bulk fetch feature vectors for the chunk
@@ -1665,6 +1679,7 @@ class SimilarityService:
         start_time = time.time()
         chunk_size = 5
         total_sims = 0
+        last_t, last_done, last_sims = start_time, 0, 0
         pool_small_fids = (
             []
         )  # below min_features -> exact FunctionID-hash match instead
@@ -1673,14 +1688,19 @@ class SimilarityService:
 
             # Update Progress
             if job_service and job_id:
-                elapsed = time.time() - start_time
+                now = time.time()
+                elapsed = now - start_time
                 done = i
                 speed = done / elapsed if elapsed > 0 else 0
                 sim_speed = total_sims / elapsed if elapsed > 0 else 0
+                d_t = now - last_t
+                cur_speed = (done - last_done) / d_t if d_t > 0 else 0
+                cur_sim_speed = (total_sims - last_sims) / d_t if d_t > 0 else 0
+                last_t, last_done, last_sims = now, done, total_sims
                 job_service.update_progress(
                     job_id,
                     int(done / total * 100),
-                    f"Building file {file_md5} pool sim: {done}/{total} functions ({speed:.1f} fn/s, {sim_speed:.1f} sim/s)",
+                    f"Building file {file_md5} pool sim: {done}/{total} functions ({speed:.1f} fn/s, {sim_speed:.1f} sim/s, cur {cur_speed:.1f} fn/s, {cur_sim_speed:.1f} sim/s)",
                 )
 
             # Use a pipeline to batch any LSH setup writes for this chunk
@@ -2483,6 +2503,7 @@ class SimilarityService:
 
         batch_size = 200
         start_time = time.time()
+        last_t, last_done = start_time, 0
 
         for i in range(0, total, batch_size):
             batch_ids = similarity_ids[i : i + batch_size]
@@ -2583,14 +2604,18 @@ class SimilarityService:
 
             # 5. Progress updates
             if job_service and job_id:
-                elapsed = time.time() - start_time
+                now = time.time()
+                elapsed = now - start_time
                 done = min(i + batch_size, total)
                 speed = done / elapsed if elapsed > 0 else 0
+                d_t = now - last_t
+                cur_speed = (done - last_done) / d_t if d_t > 0 else 0
+                last_t, last_done = now, done
                 pct = int(done / total * 100)
                 job_service.update_progress(
                     job_id,
                     pct,
-                    f"Indexing similarities: {done}/{total} ({speed:.1f} sim/s)",
+                    f"Indexing similarities: {done}/{total} ({speed:.1f} sim/s, cur {cur_speed:.1f} sim/s)",
                 )
 
         if job_service and job_id:

--- a/bsimvis/app/static/js/binary_similarity.js
+++ b/bsimvis/app/static/js/binary_similarity.js
@@ -949,6 +949,11 @@ function binSimFilterChange(shouldApply = false) {
             if (minEl) window[`bsim-flt-${prefix}-${suffix}-min-val`] = minEl.value;
             if (maxEl) window[`bsim-flt-${prefix}-${suffix}-max-val`] = maxEl.value;
         });
+        const noteSuffixes = prefix === 'matched' ? ['note-a', 'note-b'] : ['note'];
+        noteSuffixes.forEach(suffix => {
+            const el = document.getElementById(`bsim-flt-${prefix}-${suffix}`);
+            if (el) window[`bsim-flt-${prefix}-${suffix}-val`] = el.value;
+        });
     });
 
     if (shouldApply) {
@@ -966,6 +971,14 @@ const funcSearchHaystack = (fid) => {
 
 const applyFilters = (items, prefix) => {
     const q = (document.getElementById(`bsim-flt-${prefix}-q`)?.value || '').trim().toLowerCase();
+    const checkNotes = (funcsList, searchOwner) => {
+        if (!searchOwner) return true;
+        return funcsList.some(fid => {
+            const owners = (binSimDataCache.functions_metadata && binSimDataCache.functions_metadata[fid]?.note_owners) || [];
+            return owners.some(o => o.toLowerCase().includes(searchOwner));
+        });
+    };
+
     return items.filter(item => {
         if (q) {
             const fids = item.funcs_a
@@ -974,6 +987,19 @@ const applyFilters = (items, prefix) => {
             const hay = fids.map(funcSearchHaystack).join(' ');
             if (!hay.includes(q)) return false;
         }
+
+        const noteA = (document.getElementById(`bsim-flt-${prefix}-note-a`)?.value || '').trim().toLowerCase();
+        if (noteA && !checkNotes(item.funcs_a || [], noteA)) return false;
+
+        const noteB = (document.getElementById(`bsim-flt-${prefix}-note-b`)?.value || '').trim().toLowerCase();
+        if (noteB && !checkNotes(item.funcs_b || [], noteB)) return false;
+
+        const noteU = (document.getElementById(`bsim-flt-${prefix}-note`)?.value || '').trim().toLowerCase();
+        if (noteU) {
+            const fids = item.funcs || (item.func_id ? [item.func_id] : []);
+            if (!checkNotes(fids, noteU)) return false;
+        }
+
         const count = item.count_a !== undefined ? Math.max(item.count_a, item.count_b) : item.funcs.length;
         const caMin = parseFloat(document.getElementById(`bsim-flt-${prefix}-ca-min`)?.value || document.getElementById(`bsim-flt-${prefix}-c-min`)?.value);
         const caMax = parseFloat(document.getElementById(`bsim-flt-${prefix}-ca-max`)?.value || document.getElementById(`bsim-flt-${prefix}-c-max`)?.value);
@@ -1070,7 +1096,7 @@ function renderBinSimTables(isFilterChange = false) {
     const renderFuncBadge = (fid) => {
         const f = buildFuncObj(fid);
         const sig = (typeof EntityRenderer !== 'undefined')
-            ? EntityRenderer.renderFunction(f, { isTable: true })
+            ? EntityRenderer.renderFunction(f, { isTable: true, hideNote: true, showActions: false })
             : (f.function_name || fid);
         const tagsHtml = (typeof EntityRenderer !== 'undefined')
             ? EntityRenderer.renderTag('function', fid, f.tags, f.user_tags) : '';
@@ -1106,7 +1132,12 @@ function renderBinSimTables(isFilterChange = false) {
             <input type="text" oninput="binSimFilterChange(true)" onkeydown="if(event.key === 'Enter') binSimFilterChange(true)" id="bsim-flt-${prefix}-q" placeholder="Search name / tag / addr..." style="font-size:0.65rem; box-sizing:border-box; width:100%;">
         </div>`;
 
-    const restoreFilters = (prefix, suffixes) => {
+    const noteFilterHtml = (prefix, suffix) => `
+        <div onclick="event.stopPropagation()">
+            <input type="text" oninput="binSimFilterChange(true)" onkeydown="if(event.key === 'Enter') binSimFilterChange(true)" id="bsim-flt-${prefix}-${suffix}" placeholder="Note Owner..." style="font-size:0.65rem; box-sizing:border-box; width:100%;">
+        </div>`;
+
+    const restoreFilters = (prefix, suffixes, noteSuffixes = []) => {
         const qEl = document.getElementById(`bsim-flt-${prefix}-q`);
         if (qEl && window[`bsim-flt-${prefix}-q-val`]) qEl.value = window[`bsim-flt-${prefix}-q-val`];
         suffixes.forEach(suffix => {
@@ -1114,6 +1145,10 @@ function renderBinSimTables(isFilterChange = false) {
             const maxEl = document.getElementById(`bsim-flt-${prefix}-${suffix}-max`);
             if (minEl && window[`bsim-flt-${prefix}-${suffix}-min-val`]) minEl.value = window[`bsim-flt-${prefix}-${suffix}-min-val`];
             if (maxEl && window[`bsim-flt-${prefix}-${suffix}-max-val`]) maxEl.value = window[`bsim-flt-${prefix}-${suffix}-max-val`];
+        });
+        noteSuffixes.forEach(suffix => {
+            const el = document.getElementById(`bsim-flt-${prefix}-${suffix}`);
+            if (el && window[`bsim-flt-${prefix}-${suffix}-val`]) el.value = window[`bsim-flt-${prefix}-${suffix}-val`];
         });
     };
 
@@ -1123,23 +1158,25 @@ function renderBinSimTables(isFilterChange = false) {
         if (thead && !isFilterChange) {
             thead.innerHTML = `
                 <tr>
-                    <th style="text-align:left; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('matched', 'cluster_name')">Cluster <small>${getSortIcon('matched', 'cluster_name')}</small><div class="resizer"></div></th>
-                    <th style="text-align:center; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('matched', 'avg_features')">Avg Feat <small>${getSortIcon('matched', 'avg_features')}</small><div class="resizer"></div></th>
+                    <th style="text-align:left; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('matched', 'cohesion')">Similarity <small>${getSortIcon('matched', 'cohesion')}</small><div class="resizer"></div></th>
+                    <th style="text-align:center; padding:10px; border-bottom:1px solid var(--border); width: 50px;">Notes A</th>
                     <th style="text-align:center; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('matched', 'count_a')">Funcs A <small>${getSortIcon('matched', 'count_a')}</small><div class="resizer"></div></th>
                     <th style="text-align:center; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('matched', 'count_b')">Funcs B <small>${getSortIcon('matched', 'count_b')}</small><div class="resizer"></div></th>
-                    <th style="text-align:left; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('matched', 'cohesion')">Cohesion <small>${getSortIcon('matched', 'cohesion')}</small><div class="resizer"></div></th>
-                    <th style="text-align:left; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('matched', 'sim_rarity')">Sim Rarity <small>${getSortIcon('matched', 'sim_rarity')}</small><div class="resizer"></div></th>
+                    <th style="text-align:center; padding:10px; border-bottom:1px solid var(--border); width: 50px;">Notes B</th>
+                    <th style="text-align:left; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('matched', 'sim_rarity')">Rarity <small>${getSortIcon('matched', 'sim_rarity')}</small><div class="resizer"></div></th>
+                    <th style="text-align:left; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('matched', 'cluster_name')">Cluster <small>${getSortIcon('matched', 'cluster_name')}</small><div class="resizer"></div></th>
                 </tr>
                 <tr class="filter-row">
-                    <th>${searchHtml('matched')}</th>
-                    <th>${filterHtml('matched', 'feat')}</th>
+                    <th>${filterHtml('matched', 'coh')}</th>
+                    <th>${noteFilterHtml('matched', 'note-a')}</th>
                     <th>${filterHtml('matched', 'ca')}</th>
                     <th>${filterHtml('matched', 'cb')}</th>
-                    <th>${filterHtml('matched', 'coh')}</th>
+                    <th>${noteFilterHtml('matched', 'note-b')}</th>
                     <th>${filterHtml('matched', 'rar')}</th>
+                    <th>${searchHtml('matched')}</th>
                 </tr>
             `;
-            restoreFilters('matched', ['feat', 'ca', 'cb', 'coh', 'rar']);
+            restoreFilters('matched', ['feat', 'ca', 'cb', 'coh', 'rar'], ['note-a', 'note-b']);
         }
     }
 
@@ -1151,9 +1188,58 @@ function renderBinSimTables(isFilterChange = false) {
             tbodyMatched.innerHTML = matched.map(m => {
                 const cleanName = m.cluster_name.replace(/'/g, "\\'");
                 const escUuid = m.cluster_uuid;
-                const size = m.count_a + m.count_b;
-                const cohesion = m.cohesion || 0;
-                const avgFeat = m.avg_features || 0;
+                const notesAHtml = m.funcs_a.map(fid => {
+                    const fObj = buildFuncObj(fid);
+                    return `<div style="min-height:24px; display:flex; align-items:center; justify-content:center;">${EntityRenderer.renderNoteButton(fid, fObj.note_owners, { isTable: true, raw_data: fObj })}</div>`;
+                }).join('');
+                
+                const notesBHtml = m.funcs_b.map(fid => {
+                    const fObj = buildFuncObj(fid);
+                    return `<div style="min-height:24px; display:flex; align-items:center; justify-content:center;">${EntityRenderer.renderNoteButton(fid, fObj.note_owners, { isTable: true, raw_data: fObj })}</div>`;
+                }).join('');
+
+                let similarityHtml = '';
+                if (m.funcs_a.length > 0 && m.funcs_b.length > 0) {
+                    const fA = buildFuncObj(m.funcs_a[0]);
+                    const fB = buildFuncObj(m.funcs_b[0]);
+                    let diffUrl = '';
+                    if (window.buildDiffUrl) {
+                        diffUrl = window.buildDiffUrl(fA.function_id, fB.function_id);
+                    } else {
+                        // Fallback just in case
+                        let poolId = null;
+                        if (window.getRoutingState && window.getRoutingState().pool) {
+                            poolId = window.getRoutingState().pool;
+                        } else {
+                            poolId = new URLSearchParams(window.location.search).get('pool_id');
+                        }
+                        diffUrl = `/collections/${encodeURIComponent(fA.collection)}/files/${fA.file_md5}/functions/${fA.entrypoint_address}/vs/${encodeURIComponent(fB.collection)}/${fB.file_md5}/${fB.entrypoint_address}`;
+                        if (poolId) {
+                            diffUrl = `/pools/${encodeURIComponent(poolId)}` + diffUrl;
+                        }
+                    }
+
+                    const pairId = `${fA.function_id}|${fB.function_id}|unweighted_cosine`;
+
+                    similarityHtml = `
+                    <div style="display:flex; align-items:center; gap:8px;">
+                        <div style="font-size:1.1rem; font-weight:bold; color:var(--success);">${(m.cohesion * 100).toFixed(1)}%</div>
+                        <button class="btn-diff-action" 
+                            onmouseenter="showDiffPreview('${fA.function_id}', '${(fA.function_name || '').replace(/'/g, "\\'")}', '${fB.function_id}', '${(fB.function_name || '').replace(/'/g, "\\'")}', ${m.cohesion}, event)" 
+                            onmousemove="moveCodePreview(event)"
+                            onmouseleave="hideDiffPreview(event)"
+                            onclick="Nav.openPath('${diffUrl}', event, { title: 'Diff: ${fA.function_name} vs ${fB.function_name}', type: 'diff' })" 
+                            title="Run Aligned Diff" 
+                            style="padding:0 5px; font-size: 0.75rem; border-radius: 3px; display:inline-flex; align-items:center; justify-content:center; width:22px; height:22px;">
+                            <span>±</span>
+                        </button>
+                    </div>
+                    ${EntityRenderer.renderTag('similarity', pairId, m.tags || [], m.user_tags || [])}
+                    `;
+                } else {
+                    similarityHtml = `<span class="mono" style="color:var(--accent); font-weight:bold;">${(m.cohesion * 100).toFixed(1)}%</span>`;
+                }
+
                 return `
                 <tr style="border-bottom:1px solid rgba(255,255,255,0.05);"
                     data-entity-data='${JSON.stringify({
@@ -1163,17 +1249,12 @@ function renderBinSimTables(isFilterChange = false) {
                     }).replace(/'/g, "&apos;")}'
                     oncontextmenu="typeof EntityRenderer !== 'undefined' && EntityRenderer.handleContextMenu(event, 'bin_cluster', this)">
                     <td style="padding:10px;">
-                        <div class="clickable" style="font-weight:bold; color:var(--accent);"
-                             onmouseenter="if(window.parent && window.parent.showClusterTableTooltipFromIframe && window.parent !== window) { window.parent.showClusterTableTooltipFromIframe(window.name, '${escUuid}', '${cleanName}', ${size}, 1.0, ${cohesion}, ${avgFeat}, event); } else if(window.showClusterTableTooltip) { window.showClusterTableTooltip(event, '${escUuid}', '${cleanName}', ${size}, 1.0, ${cohesion}, ${avgFeat}); }"
-                             onmousemove="if(window.parent && window.parent.moveClusterTableTooltipFromIframe && window.parent !== window) { window.parent.moveClusterTableTooltipFromIframe(window.name, event); } else if(window.moveClusterTableTooltip) { window.moveClusterTableTooltip(event); }"
-                             onmouseleave="if(window.parent && window.parent.hideClusterTableTooltipFromIframe && window.parent !== window) { window.parent.hideClusterTableTooltipFromIframe(); } else if(window.hideClusterTableTooltip) { window.hideClusterTableTooltip(); }"
-                             onclick="openClusterView('${escUuid}', '${cleanName}', event)">
-                             ${m.cluster_name}
-                        </div>
-                        <div class="mono dim" style="font-size:0.65rem;">UUID: ${m.cluster_uuid}</div>
+                        ${similarityHtml}
                     </td>
                     <td style="padding:10px; text-align:center;">
-                        <div class="mono dim">${(m.avg_features || 0).toFixed(1)}</div>
+                        <div style="display:flex; flex-direction:column; gap:6px; max-height:120px; overflow-y:auto;">
+                            ${notesAHtml}
+                        </div>
                     </td>
                     <td style="padding:8px; text-align:left; vertical-align:top; min-width:220px;">
                         ${m.count_a > 1 ? `<div style="margin-bottom:4px; font-weight:bold; font-size:0.7rem;" class="dim">${m.count_a} funcs</div>` : ''}
@@ -1187,16 +1268,22 @@ function renderBinSimTables(isFilterChange = false) {
                             ${m.funcs_b.map(renderFuncBadge).join('')}
                         </div>
                     </td>
-                    <td style="padding:10px;">
-                        <div style="display:flex; align-items:center; gap:8px;">
-                            <div style="flex:1; height:4px; background:#333; border-radius:2px; overflow:hidden; min-width:40px;">
-                                <div style="height:100%; background:var(--info); width:${(m.cohesion * 100).toFixed(0)}%"></div>
-                            </div>
-                            <span class="dim">${m.cohesion.toFixed(2)}</span>
+                    <td style="padding:10px; text-align:center;">
+                        <div style="display:flex; flex-direction:column; gap:6px; max-height:120px; overflow-y:auto;">
+                            ${notesBHtml}
                         </div>
                     </td>
                     <td style="padding:10px;">
                         <div class="mono dim">${m.sim_rarity.toFixed(2)}</div>
+                    </td>
+                    <td style="padding:10px;">
+                        ${EntityRenderer.renderClusterCard([{
+                            cluster_id: m.cluster_id,
+                            cluster_uuid: m.cluster_uuid,
+                            cluster_name: m.cluster_name,
+                            cohesion_score: m.cohesion || 1.0,
+                            member_count: 1 // ponytail: simple placeholder count for matched pairs card
+                        }])}
                     </td>
                 </tr>
                 `;
@@ -1213,43 +1300,72 @@ function renderBinSimTables(isFilterChange = false) {
             thead.innerHTML = `
                 <tr>
                     <th style="text-align:left; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('${stateKey}', 'func_name')">Function <small>${getSortIcon(stateKey, 'func_name')}</small><div class="resizer"></div></th>
-                    <th style="text-align:center; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('${stateKey}', 'avg_features')">Features <small>${getSortIcon(stateKey, 'avg_features')}</small><div class="resizer"></div></th>
+                    <th style="text-align:center; padding:10px; border-bottom:1px solid var(--border); width: 50px;">Notes</th>
                     <th style="text-align:left; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('${stateKey}', 'sim_rarity')">Rarity <small>${getSortIcon(stateKey, 'sim_rarity')}</small><div class="resizer"></div></th>
+                    <th style="text-align:left; padding:10px; border-bottom:1px solid var(--border);" class="sortable resizable-th" onclick="setBinSimSort('${stateKey}', 'cluster_name')">Cluster <small>${getSortIcon(stateKey, 'cluster_name')}</small><div class="resizer"></div></th>
                 </tr>
                 <tr class="filter-row">
                     <th>${searchHtml(prefix)}</th>
-                    <th>${filterHtml(prefix, 'feat')}</th>
+                    <th>${noteFilterHtml(prefix, 'note')}</th>
                     <th>${filterHtml(prefix, 'rar')}</th>
+                    <th>${searchHtml(prefix + '-cl')}</th>
                 </tr>
             `;
-            restoreFilters(prefix, ['feat', 'rar']);
+            restoreFilters(prefix, ['feat', 'rar'], ['note']);
         }
 
-        let items = applyFilters(itemsRaw || [], prefix);
+        // Apply secondary text search filter for cluster name if present
+        let items = (itemsRaw || []).filter(u => {
+            const clFltVal = window[`bsim-flt-${prefix}-cl-q-val`] || document.getElementById(`bsim-flt-${prefix}-cl-q`)?.value || '';
+            if (clFltVal) {
+                const term = clFltVal.toLowerCase();
+                const clName = (u.cluster_name || 'unclustered').toLowerCase();
+                if (!clName.includes(term)) return false;
+            }
+            return true;
+        });
+
+        items = applyFilters(items, prefix);
         items = sortItems(items, state);
 
         if (items.length === 0) {
-            tbody.innerHTML = '<tr><td colspan="3" style="text-align:center; padding:20px;">No unmatched functions</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="4" style="text-align:center; padding:20px;">No unmatched functions</td></tr>';
             return;
         }
         tbody.innerHTML = items.map(u => {
-            const avgFeat = u.avg_features || 0;
             const rarity = (u.sim_rarity !== undefined) ? u.sim_rarity : 0;
+            const funcs = u.funcs || (u.func_id ? [u.func_id] : []);
+            const notesHtml = funcs.map(fid => {
+                const fObj = buildFuncObj(fid);
+                return `<div style="min-height:24px; display:flex; align-items:center; justify-content:center;">${EntityRenderer.renderNoteButton(fid, fObj.note_owners, { isTable: true, raw_data: fObj })}</div>`;
+            }).join('');
             return `
-            <tr style="border-bottom:1px solid rgba(255,255,255,0.05);">
+            <tr style="border-bottom:1px solid rgba(255,255,255,0.05);"
+                data-entity-data='${JSON.stringify({
+                    cluster_id: u.cluster_id,
+                    cluster_uuid: u.cluster_uuid,
+                    cluster_name: u.cluster_name
+                }).replace(/'/g, "&apos;")}'
+                oncontextmenu="typeof EntityRenderer !== 'undefined' && EntityRenderer.handleContextMenu(event, 'bin_cluster', this)">
                 <td style="padding:8px;">
-                    ${renderFuncBadge(u.func_id)}
+                    ${funcs.map(renderFuncBadge).join('')}
                 </td>
                 <td style="padding:10px; text-align:center;">
-                    <div class="mono dim">${avgFeat.toFixed(0)}</div>
+                    <div style="display:flex; flex-direction:column; gap:6px;">
+                        ${notesHtml}
+                    </div>
                 </td>
                 <td style="padding:10px;">
-                    <div style="display:flex; align-items:center; gap:8px;">
-                        <div style="flex:1; height:4px; background:#333; border-radius:2px; overflow:hidden; min-width:30px;">
-                            <div style="height:100%; background:var(--warning, #fd971f); width:${(rarity * 100).toFixed(0)}%"></div>
-                        </div>
-                        <span class="dim">${rarity.toFixed(2)}</span>
-                    </div>
+                    <span class="dim">${rarity.toFixed(2)}</span>
+                </td>
+                <td style="padding:10px;">
+                    ${(u.cluster_id || u.cluster_uuid) ? EntityRenderer.renderClusterCard([{
+                        cluster_id: u.cluster_id,
+                        cluster_uuid: u.cluster_uuid,
+                        cluster_name: u.cluster_name,
+                        cohesion_score: u.cohesion || 1.0,
+                        member_count: 1
+                    }]) : ''}
                 </td>
             </tr>
             `;
@@ -1481,5 +1597,33 @@ if (typeof window.showFunctionCodeById === 'undefined') {
         }
     };
 }
+
+// Refresh logic for function rows on note updates
+window.refreshFunctionRow = async function(funcId) {
+    if (!binSimDataCache) return;
+    try {
+        const parts = funcId.split(':');
+        const collection = parts[0];
+        const md5 = parts[2];
+        const addr = parts[3];
+        const res = await fetch(`/api/function/search?collection=${collection}&entrypoint_address=${addr}&file_md5=${md5}`);
+        const data = await res.json();
+        if (data.functions && data.functions.length > 0) {
+            const f = data.functions[0];
+            if (!binSimDataCache.functions_metadata) {
+                binSimDataCache.functions_metadata = {};
+            }
+            binSimDataCache.functions_metadata[funcId] = {
+                ...(binSimDataCache.functions_metadata[funcId] || {}),
+                note_owners: f.note_owners || [],
+                note_count: f.note_count || 0
+            };
+            renderBinSimTables();
+        }
+    } catch (e) {
+        console.error("Failed to refresh function note badge in comparison view:", e);
+    }
+};
+
 
 

--- a/bsimvis/app/static/js/dashboard.js
+++ b/bsimvis/app/static/js/dashboard.js
@@ -190,13 +190,27 @@ const routes = {
     'collections': {
         title: 'Collections',
         api: '/api/collection/search',
-        headers: ['Name', 'Batches', 'Files', 'Functions', 'Last Updated', 'Actions'],
+        headers: [
+            { label: 'Name', sort: 'name' },
+            { label: 'Batches', sort: 'total_batches' },
+            { label: 'Files', sort: 'total_files' },
+            { label: 'Functions', sort: 'total_functions' },
+            { label: 'Last Updated', sort: 'last_updated' },
+            'Actions'
+        ],
         renderer: renderCollections
     },
     'pools': {
         title: 'Pools',
         api: '/api/pool',
-        headers: ['Pool ID', 'Name', 'Collections', 'Sync Status', 'Created At', 'Actions'],
+        headers: [
+            { label: 'Pool ID', sort: 'id' },
+            { label: 'Name', sort: 'name' },
+            'Collections',
+            { label: 'Sync Status', sort: 'sync_status' },
+            { label: 'Created At', sort: 'created_at' },
+            'Actions'
+        ],
         renderer: renderPools
     },
     'batches': {
@@ -1060,8 +1074,8 @@ function updateUI(viewKey, collection, params, route, force = false) {
     }
 
     if (pathChanged) {
-        if (path === 'function-similarity' || path === 'functions' || path === 'files' || path === 'clusters' || path === 'bin-clusters' || path === 'features-global' || path === 'binary-similarity' || path === 'jobs') {
-            const applyFn = path === 'function-similarity' ? 'applySimSearch' : (path === 'functions' ? 'applyAdvancedFuncSearch' : (path === 'files' ? 'applyAdvancedFileSearch' : (path === 'features-global' ? 'applyAdvancedFeatureSearch' : (path === 'binary-similarity' ? 'applyBinSimSearch' : (path === 'bin-clusters' ? 'applyBinClusterSearch' : (path === 'clusters' ? 'applyClusterSearch' : 'applyJobSearch'))))));
+        if (path === 'function-similarity' || path === 'functions' || path === 'files' || path === 'clusters' || path === 'bin-clusters' || path === 'features-global' || path === 'binary-similarity' || path === 'jobs' || path === 'collections' || path === 'pools') {
+            const applyFn = path === 'function-similarity' ? 'applySimSearch' : (path === 'functions' ? 'applyAdvancedFuncSearch' : (path === 'files' ? 'applyAdvancedFileSearch' : (path === 'features-global' ? 'applyAdvancedFeatureSearch' : (path === 'binary-similarity' ? 'applyBinSimSearch' : (path === 'bin-clusters' ? 'applyBinClusterSearch' : (path === 'clusters' ? 'applyClusterSearch' : (path === 'collections' ? 'applyCollectionSearch' : (path === 'pools' ? 'applyPoolSearch' : 'applyJobSearch'))))))));
 
             let settingsHtml = '';
             settingsEl.style.display = 'flex';
@@ -1350,6 +1364,31 @@ function updateUI(viewKey, collection, params, route, force = false) {
                     <th><div style="display:flex; flex-direction:column; gap:2px;"><input type="text" id="flt-bin-cluster-file-name" placeholder="File Name..." value="${p.get('file_name') || ''}" onchange="debouncedSearch(applyBinClusterSearch)" onkeydown="handleFilterKey(event, applyBinClusterSearch)" style="font-size:0.6rem; width: 100%; box-sizing: border-box;"><input type="text" id="flt-bin-cluster-file-md5" placeholder="MD5..." value="${p.get('file_md5') || ''}" onchange="debouncedSearch(applyBinClusterSearch)" onkeydown="handleFilterKey(event, applyBinClusterSearch)" style="font-size:0.6rem; width: 100%; box-sizing: border-box;"></div></th>
                 </tr>`;
                 thead.innerHTML = headHtml;
+            } else if (path === 'collections') {
+                const msToDate = (ms) => ms ? new Date(+ms).toISOString().slice(0, 10) : '';
+                const numRange = (minId, maxId, minP, maxP) => `<th><div style="display:flex; align-items:center; gap:2px;"><input type="number" id="${minId}" placeholder="Min..." min="0" value="${p.get(minP) || ''}" onchange="debouncedSearch(applyCollectionSearch)" onkeydown="handleFilterKey(event, applyCollectionSearch)" style="font-size:0.6rem; width:45%; box-sizing:border-box;"><span class="dim" style="font-size:0.6rem">-</span><input type="number" id="${maxId}" placeholder="Max..." min="0" value="${p.get(maxP) || ''}" onchange="debouncedSearch(applyCollectionSearch)" onkeydown="handleFilterKey(event, applyCollectionSearch)" style="font-size:0.6rem; width:45%; box-sizing:border-box;"></div></th>`;
+                headHtml += `<tr class="filter-row">
+                    <th><input type="text" id="flt-coll-name" placeholder="Name..." value="${p.get('name') || ''}" onchange="debouncedSearch(applyCollectionSearch)" onkeydown="handleFilterKey(event, applyCollectionSearch)" style="font-size:0.65rem; width:100%; box-sizing:border-box;"></th>
+                    ${numRange('flt-coll-min-batches', 'flt-coll-max-batches', 'min_batches', 'max_batches')}
+                    ${numRange('flt-coll-min-files', 'flt-coll-max-files', 'min_files', 'max_files')}
+                    ${numRange('flt-coll-min-functions', 'flt-coll-max-functions', 'min_functions', 'max_functions')}
+                    <th><div style="display:flex; align-items:center; gap:2px;"><input type="date" id="flt-coll-min-date" title="From" value="${msToDate(p.get('min_last_updated'))}" onchange="debouncedSearch(applyCollectionSearch)" style="font-size:0.6rem; width:48%; box-sizing:border-box;"><input type="date" id="flt-coll-max-date" title="To" value="${msToDate(p.get('max_last_updated'))}" onchange="debouncedSearch(applyCollectionSearch)" style="font-size:0.6rem; width:48%; box-sizing:border-box;"></div></th>
+                    <th></th>
+                </tr>`;
+                thead.innerHTML = headHtml;
+            } else if (path === 'pools') {
+                const msToDate = (ms) => ms ? new Date(+ms).toISOString().slice(0, 10) : '';
+                const status = p.get('sync_status') || '';
+                const statusOpts = ['', 'current', 'outdated', 'created'].map(s => `<option value="${s}" ${status === s ? 'selected' : ''}>${s ? s.toUpperCase() : 'All'}</option>`).join('');
+                headHtml += `<tr class="filter-row">
+                    <th><input type="text" id="flt-pool-id" placeholder="ID..." value="${p.get('id') || ''}" onchange="debouncedSearch(applyPoolSearch)" onkeydown="handleFilterKey(event, applyPoolSearch)" style="font-size:0.65rem; width:100%; box-sizing:border-box;"></th>
+                    <th><input type="text" id="flt-pool-name" placeholder="Name..." value="${p.get('name') || ''}" onchange="debouncedSearch(applyPoolSearch)" onkeydown="handleFilterKey(event, applyPoolSearch)" style="font-size:0.65rem; width:100%; box-sizing:border-box;"></th>
+                    <th></th>
+                    <th><select id="flt-pool-status" onchange="applyPoolSearch()" style="background:#000; border:1px solid #333; color:var(--text); padding:2px; font-size:0.65rem; border-radius:2px; width:100%; box-sizing:border-box;">${statusOpts}</select></th>
+                    <th><div style="display:flex; align-items:center; gap:2px;"><input type="date" id="flt-pool-min-date" title="From" value="${msToDate(p.get('min_created_at'))}" onchange="debouncedSearch(applyPoolSearch)" style="font-size:0.6rem; width:48%; box-sizing:border-box;"><input type="date" id="flt-pool-max-date" title="To" value="${msToDate(p.get('max_created_at'))}" onchange="debouncedSearch(applyPoolSearch)" style="font-size:0.6rem; width:48%; box-sizing:border-box;"></div></th>
+                    <th></th>
+                </tr>`;
+                thead.innerHTML = headHtml;
             }
 
             // Graph/Hierarchy Container Visibility Logic
@@ -1395,6 +1434,10 @@ function updateUI(viewKey, collection, params, route, force = false) {
                     searchArea.innerHTML = `<div class="filter-bar"><div class="search-input-wrapper"><input type="text" id="bin-cluster-search-input" placeholder="Search by keywords..." autofocus value="${p.get('q') || ''}" onchange="debouncedSearch(applyBinClusterSearch)" onkeydown="handleFilterKey(event, applyBinClusterSearch)"><i class="fa-solid fa-magnifying-glass search-icon-btn" onclick="applyBinClusterSearch()" title="Search"></i></div></div>`;
                 } else if (path === 'binary-similarity') {
                     searchArea.innerHTML = `<div class="filter-bar" style="gap:20px"><div style="display:flex; gap:10px; align-items:center;"><div class="search-input-wrapper"><input type="text" id="bsim-search-input" placeholder="Search similarities by keywords..." autofocus value="${p.get('q') || ''}" onchange="debouncedSearch(applyBinSimSearch)" onkeydown="handleFilterKey(event, applyBinSimSearch)"><i class="fa-solid fa-magnifying-glass search-icon-btn" onclick="applyBinSimSearch()" title="Search"></i></div></div></div>`;
+                } else if (path === 'collections') {
+                    searchArea.innerHTML = `<div class="filter-bar"><div class="search-input-wrapper"><input type="text" id="collection-search-input" placeholder="Search collections by name..." autofocus value="${p.get('q') || ''}" onchange="debouncedSearch(applyCollectionSearch)" onkeydown="handleFilterKey(event, applyCollectionSearch)"><i class="fa-solid fa-magnifying-glass search-icon-btn" onclick="applyCollectionSearch()" title="Search"></i></div></div>`;
+                } else if (path === 'pools') {
+                    searchArea.innerHTML = `<div class="filter-bar"><div class="search-input-wrapper"><input type="text" id="pool-search-input" placeholder="Search pools by name, id, collection..." autofocus value="${p.get('q') || ''}" onchange="debouncedSearch(applyPoolSearch)" onkeydown="handleFilterKey(event, applyPoolSearch)"><i class="fa-solid fa-magnifying-glass search-icon-btn" onclick="applyPoolSearch()" title="Search"></i></div></div>`;
                 } else { searchArea.innerHTML = ''; }
             }
         } else {
@@ -1414,7 +1457,9 @@ function updateUI(viewKey, collection, params, route, force = false) {
         syncInput('cluster-search-input', 'q');
         syncInput('bin-cluster-search-input', 'q');
         syncInput('bsim-search-input', 'q');
- 
+        syncInput('collection-search-input', 'q');
+        syncInput('pool-search-input', 'q');
+
         // Sync view settings
         syncInput('sim-pool-limit', 'pool_limit');
         syncInput('sim-limit', 'limit');
@@ -1452,6 +1497,17 @@ function updateUI(viewKey, collection, params, route, force = false) {
             syncInput('flt-bin-cluster-uuid', 'cluster_uuid'); syncInput('flt-bin-cluster-id', 'cluster_id'); syncInput('flt-bin-cluster-name', 'cluster_name'); syncSelect('bin-cluster-name-type', 'cluster_name_type', 'file');
             syncInput('flt-bin-cluster-min-count', 'min_count'); syncInput('flt-bin-cluster-max-count', 'max_count'); syncInput('flt-bin-cluster-min-stability', 'min_stability'); syncInput('flt-bin-cluster-min-cohesion', 'min_cohesion'); syncInput('flt-bin-cluster-max-cohesion', 'max_cohesion');
             syncInput('flt-bin-cluster-file-name', 'file_name'); syncInput('flt-bin-cluster-file-md5', 'file_md5');
+        } else if (path === 'collections') {
+            const syncDate = (id, paramName) => { const el = document.getElementById(id); if (el) { const ms = p.get(paramName); el.value = ms ? new Date(+ms).toISOString().slice(0, 10) : ''; } };
+            syncInput('flt-coll-name', 'name');
+            syncInput('flt-coll-min-batches', 'min_batches'); syncInput('flt-coll-max-batches', 'max_batches');
+            syncInput('flt-coll-min-files', 'min_files'); syncInput('flt-coll-max-files', 'max_files');
+            syncInput('flt-coll-min-functions', 'min_functions'); syncInput('flt-coll-max-functions', 'max_functions');
+            syncDate('flt-coll-min-date', 'min_last_updated'); syncDate('flt-coll-max-date', 'max_last_updated');
+        } else if (path === 'pools') {
+            const syncDate = (id, paramName) => { const el = document.getElementById(id); if (el) { const ms = p.get(paramName); el.value = ms ? new Date(+ms).toISOString().slice(0, 10) : ''; } };
+            syncInput('flt-pool-id', 'id'); syncInput('flt-pool-name', 'name'); syncSelect('flt-pool-status', 'sync_status', '');
+            syncDate('flt-pool-min-date', 'min_created_at'); syncDate('flt-pool-max-date', 'max_created_at');
         } else if (path === 'binary-similarity') {
             syncSelect('bsim-score-type', 'sort', 'score'); syncInput('bsim-min-score', 'min_score'); syncInput('bsim-max-score', 'max_score'); syncInput('bsim-file-name', 'file_name'); syncInput('bsim-md5', 'md5'); syncInput('bsim-arch', 'arch');
             syncInput('bsim-min-funcs', 'min_funcs'); syncInput('bsim-max-funcs', 'max_funcs'); syncInput('bsim-min-cov', 'min_coverage'); syncInput('bsim-max-cov', 'max_coverage'); syncInput('bsim-min-shared', 'min_shared');
@@ -3016,6 +3072,61 @@ function applyClusterSearch() {
     navigate(viewKey, params);
 }
 
+// Set param from an element value, or delete when empty
+function _setOrDel(params, key, val) {
+    if (val !== undefined && val !== null && val !== '') params.set(key, val);
+    else params.delete(key);
+}
+// Date input (YYYY-MM-DD) -> Unix ms. endOfDay adds a day span for max bounds.
+function _dateToMs(val, endOfDay) {
+    if (!val) return '';
+    const ms = Date.parse(val);
+    if (isNaN(ms)) return '';
+    return String(endOfDay ? ms + 86399999 : ms);
+}
+
+function applyCollectionSearch() {
+    if (filterDebounceTimer) clearTimeout(filterDebounceTimer);
+    const { viewKey, params } = getRoutingState();
+
+    _setOrDel(params, 'q', document.getElementById('collection-search-input')?.value);
+    _setOrDel(params, 'name', document.getElementById('flt-coll-name')?.value);
+    _setOrDel(params, 'min_batches', document.getElementById('flt-coll-min-batches')?.value);
+    _setOrDel(params, 'max_batches', document.getElementById('flt-coll-max-batches')?.value);
+    _setOrDel(params, 'min_files', document.getElementById('flt-coll-min-files')?.value);
+    _setOrDel(params, 'max_files', document.getElementById('flt-coll-max-files')?.value);
+    _setOrDel(params, 'min_functions', document.getElementById('flt-coll-min-functions')?.value);
+    _setOrDel(params, 'max_functions', document.getElementById('flt-coll-max-functions')?.value);
+    _setOrDel(params, 'min_last_updated', _dateToMs(document.getElementById('flt-coll-min-date')?.value, false));
+    _setOrDel(params, 'max_last_updated', _dateToMs(document.getElementById('flt-coll-max-date')?.value, true));
+
+    const countLimit = document.getElementById('sim-limit')?.value;
+    params.set('limit', countLimit || DEFAULT_PAGE_LIMIT);
+
+    currentOffset = 0;
+    isEndOfResults = false;
+    navigate(viewKey, params);
+}
+
+function applyPoolSearch() {
+    if (filterDebounceTimer) clearTimeout(filterDebounceTimer);
+    const { viewKey, params } = getRoutingState();
+
+    _setOrDel(params, 'q', document.getElementById('pool-search-input')?.value);
+    _setOrDel(params, 'id', document.getElementById('flt-pool-id')?.value);
+    _setOrDel(params, 'name', document.getElementById('flt-pool-name')?.value);
+    _setOrDel(params, 'sync_status', document.getElementById('flt-pool-status')?.value);
+    _setOrDel(params, 'min_created_at', _dateToMs(document.getElementById('flt-pool-min-date')?.value, false));
+    _setOrDel(params, 'max_created_at', _dateToMs(document.getElementById('flt-pool-max-date')?.value, true));
+
+    const countLimit = document.getElementById('sim-limit')?.value;
+    params.set('limit', countLimit || DEFAULT_PAGE_LIMIT);
+
+    currentOffset = 0;
+    isEndOfResults = false;
+    navigate(viewKey, params);
+}
+
 function renderBinClusters(items) {
     const { collection, params } = getRoutingState();
     const nameType = params.get('cluster_name_type') || 'file';
@@ -3368,6 +3479,8 @@ window.applyAdvancedFuncSearch = applyAdvancedFuncSearch;
 window.applySimSearch = applySimSearch;
 window.applyBinSimSearch = applyBinSimSearch;
 window.applyClusterSearch = applyClusterSearch;
+window.applyCollectionSearch = applyCollectionSearch;
+window.applyPoolSearch = applyPoolSearch;
 window.switchClusterView = switchClusterView;
 window.renameCluster = renameCluster;
 window.refreshData = refreshData;

--- a/bsimvis/app/static/js/notes.js
+++ b/bsimvis/app/static/js/notes.js
@@ -539,6 +539,8 @@ async function submitEditNote(funcId, noteId) {
         if (data.status === 'success') {
             currentEditingNoteId = null;
             await refreshNotes(funcId);
+            if (!isFile && window.parent?.refreshFunctionRow) window.parent.refreshFunctionRow(funcId);
+            if (isFile && window.parent?.refreshFileRow) window.parent.refreshFileRow(funcId);
         } else {
             alert(data.error || 'Failed to update note');
         }
@@ -722,6 +724,8 @@ async function saveMessageAsNote(funcId, index, btn) {
             await refreshNotes(funcId);
             btn.innerHTML = '<i class="fa-solid fa-check"></i> Saved';
             btn.disabled = true;
+            if (!isFile && window.parent?.refreshFunctionRow) window.parent.refreshFunctionRow(funcId);
+            if (isFile && window.parent?.refreshFileRow) window.parent.refreshFileRow(funcId);
         }
     } catch (e) { alert(e.message); }
 }

--- a/bsimvis/app/static/js/views/diff_view.js
+++ b/bsimvis/app/static/js/views/diff_view.js
@@ -183,8 +183,18 @@ window.DiffView = {
                     newP.collection_b = tmp.collection_a;
                     newP.md5_b = tmp.md5_a;
                     newP.addr_b = tmp.addr_a;
-                    
-                    const newUrl = `/api/diff${window.encodeDiffParams ? window.encodeDiffParams(newP) : ''}`;
+                    let newUrl = '';
+                    if (window.buildDiffUrl) {
+                        const id1 = `${newP.collection_a}:func:${newP.md5_a}:${newP.addr_a}`;
+                        const id2 = `${newP.collection_b}:func:${newP.md5_b}:${newP.addr_b}`;
+                        newUrl = window.buildDiffUrl(id1, id2);
+                    } else {
+                        newUrl = `/collections/${encodeURIComponent(newP.collection_a)}/files/${newP.md5_a}/functions/${newP.addr_a}/vs/${encodeURIComponent(newP.collection_b)}/${newP.md5_b}/${newP.addr_b}`;
+                        const poolId = window.getRoutingState?.()?.pool || null;
+                        if (poolId) {
+                            newUrl = `/pools/${encodeURIComponent(poolId)}` + newUrl;
+                        }
+                    }
                     Nav.openPath(newUrl);
                 }
             }

--- a/bsimvis/app/swagger.py
+++ b/bsimvis/app/swagger.py
@@ -463,6 +463,20 @@ class CollectionSearch(Resource):
                 "description": "Keyword search across collection names",
                 "example": "main",
             },
+            "name": {"description": "Substring filter on collection name"},
+            "sort_by": {
+                "description": "name | total_files | total_functions | total_batches | last_updated",
+                "example": "last_updated",
+            },
+            "sort_order": {"description": "asc | desc", "example": "desc"},
+            "min_files": {"description": "Min file count"},
+            "max_files": {"description": "Max file count"},
+            "min_functions": {"description": "Min function count"},
+            "max_functions": {"description": "Max function count"},
+            "min_batches": {"description": "Min batch count"},
+            "max_batches": {"description": "Max batch count"},
+            "min_last_updated": {"description": "Min last-updated (Unix ms)"},
+            "max_last_updated": {"description": "Max last-updated (Unix ms)"},
             "format": {"description": "Export format: csv or json", "example": "json"},
         }
     )
@@ -2205,9 +2219,33 @@ pool_create_model = api.model(
 
 @ns_pool.route("")
 class PoolList(Resource):
-    @ns_pool.doc(params={"collection": "Filter pools by collection membership"})
+    @ns_pool.doc(
+        params={
+            "collection": "Filter pools by collection membership",
+            "q": {
+                "description": "Keyword search across pool name / id / member collections / sync status",
+                "example": "mirai",
+            },
+            "name": {"description": "Substring filter on pool name"},
+            "sync_status": {"description": "Exact sync status: current | outdated | created"},
+            "sort_by": {
+                "description": "name | id | created_at | last_built_at | sync_status | count fields",
+                "example": "created_at",
+            },
+            "sort_order": {"description": "asc | desc", "example": "desc"},
+            "offset": {"description": "Pagination offset", "default": 0},
+            "limit": {"description": "Max results", "default": 100},
+            "refresh_sync": {
+                "description": "Recompute live sync status per pool (slower). 1 to enable.",
+            },
+            "min_created_at": {"description": "Min created-at (Unix ms)"},
+            "max_created_at": {"description": "Max created-at (Unix ms)"},
+            "min_last_built_at": {"description": "Min last-built (Unix ms)"},
+            "max_last_built_at": {"description": "Max last-built (Unix ms)"},
+        }
+    )
     def get(self):
-        """Lists all defined pools."""
+        """Lists and searches defined pools with keyword filtering and sorting."""
         from bsimvis.app.routes.pools import list_pools
 
         return list_pools()

--- a/bsimvis/worker.py
+++ b/bsimvis/worker.py
@@ -577,7 +577,9 @@ class Worker:
             # so the BSim-vs-hash split (and canonical file score) stays stable.
             from bsimvis.app.services.collection_config import resolve_and_lock
 
-            min_score = resolve_and_lock(collection, "min_score", payload.get("min_score"))
+            min_score = resolve_and_lock(
+                collection, "min_score", payload.get("min_score")
+            )
             min_features = resolve_and_lock(
                 collection, "min_features", payload.get("min_features")
             )

--- a/test_pools.py
+++ b/test_pools.py
@@ -302,12 +302,22 @@ def main():
         print(f"  Pool-specific Score:     {pool_score}")
         print()
         print("  URLs for review:")
-        print(f"    - Single Collection:                  {BASE_URL}/collections/{SINGLE_COLL}")
-        print(f"    - Separate Collection (ARM):          {BASE_URL}/collections/{SEP_COLL_ARM}")
-        print(f"    - Separate Collection (Linux):        {BASE_URL}/collections/{SEP_COLL_LINUX}")
+        print(
+            f"    - Single Collection:                  {BASE_URL}/collections/{SINGLE_COLL}"
+        )
+        print(
+            f"    - Separate Collection (ARM):          {BASE_URL}/collections/{SEP_COLL_ARM}"
+        )
+        print(
+            f"    - Separate Collection (Linux):        {BASE_URL}/collections/{SEP_COLL_LINUX}"
+        )
         print(f"    - Pool:                               {BASE_URL}/pools/{POOL_ID}")
-        print(f"    - Single Collection Comparison Diff:  {BASE_URL}/collections/{SINGLE_COLL}/files/{MD5_ARM}/vs/{SINGLE_COLL}/{MD5_LINUX}")
-        print(f"    - Pool Comparison Diff:               {BASE_URL}/pools/{POOL_ID}/collections/{SEP_COLL_ARM}/files/{MD5_ARM}/vs/{SEP_COLL_LINUX}/{MD5_LINUX}")
+        print(
+            f"    - Single Collection Comparison Diff:  {BASE_URL}/collections/{SINGLE_COLL}/files/{MD5_ARM}/vs/{SINGLE_COLL}/{MD5_LINUX}"
+        )
+        print(
+            f"    - Pool Comparison Diff:               {BASE_URL}/pools/{POOL_ID}/collections/{SEP_COLL_ARM}/files/{MD5_ARM}/vs/{SEP_COLL_LINUX}/{MD5_LINUX}"
+        )
         # ponytail: simple URL prints
         print()
 
@@ -424,7 +434,14 @@ def main():
                         norm_item = {
                             k: v
                             for k, v in item.items()
-                            if k not in ("cluster_uuid", "cluster_id", "sim_rarity", "collection_rarity", "avg_features")
+                            if k
+                            not in (
+                                "cluster_uuid",
+                                "cluster_id",
+                                "sim_rarity",
+                                "collection_rarity",
+                                "avg_features",
+                            )
                         }
                         for fkey in ("funcs_a", "funcs_b", "funcs"):
                             if fkey in norm_item and norm_item[fkey]:


### PR DESCRIPTION
## What

Brings the **Pools** and **Collections** dashboard lists up to parity with every other view: a working `q` keyword box, per-column filtering (incl. specific-field search), and sort-by-column (especially date). The generic UI machinery already existed — these two routes were just never wired in, and their endpoints ignored the sort/filter params.

## Backend
- **`_list_query.py`** (new): shared in-memory keyword / numeric-range / sort / paginate helpers. Optional `args` seam so logic is testable without a Flask request; ships a `__main__` self-check (`python3 bsimvis/app/routes/_list_query.py` → `ok`).
- **`search_collections`**: hydrate all collections → `q` (name) + `name` / count / `last_updated` filters + `sort_by`/`sort_order` (name, files, functions, batches, last_updated) → paginate.
- **`list_pools`**: `q` over name/id/collections/status, `name`/`id`/`sync_status` filters, `created_at`/`last_built_at`/count ranges, `sort_by`/`sort_order` (default `created_at desc`). `PoolService.list_pools` no longer recomputes sync status per pool on every list (now behind `?refresh_sync=1`) — that per-pool double-`get_pool` + per-collection scan was the real cost at ~1k pools.
- **swagger**: new params documented.

## Frontend (`dashboard.js`)
- Sortable headers on both routes; wired the shared `q` box, per-column filter row (text / min-max / native `<input type=date>` / sync-status `<select>`), `applyCollectionSearch` / `applyPoolSearch`, and input state-sync on re-render.

## Indexes
No new Redis index — in-memory filter/sort is correct at ≤~1k items (mirrors batch search). ZSET date indexes are the noted upgrade path if pool/collection count grows well past 1k. Marked with a `ponytail:` comment.

## Verification
- `python3 bsimvis/app/routes/_list_query.py` → `ok` (sort/range/keyword self-check).
- `node --check dashboard.js` passes; all changed Python files AST-parse.
- **Not yet exercised against a live server** (Flask unavailable in the build shell). Suggested smoke tests:
  - `GET /api/collection/search?sort_by=last_updated&sort_order=desc`
  - `GET /api/collection/search?q=<substr>&min_files=10`
  - `GET /api/pool?sort_by=created_at&sort_order=asc`
  - `GET /api/pool?q=<name>&sync_status=outdated`
  - UI: Collections & Pools views — q box, click a date header, min/max + sync-status filters.

> **Behavior note:** pool `sync_status` in the list now reflects the last stored value; pass `?refresh_sync=1` (or use the per-pool sync endpoint) to recompute live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)