### PR TITLE
fix(file view): keep inferred-metadata links in pool context

### DIFF
--- a/bsimvis/app/static/js/views/file_view.js
+++ b/bsimvis/app/static/js/views/file_view.js
@@ -254,7 +254,7 @@ window.FileView = {
                     const confObj = mapObj[k];
                     const confScore = confObj.percent;
                     const confColor = d3.interpolateRdYlGn(confScore / 100);
-                    const clusterLink = `/collections/${encodeURIComponent(collection)}/files?bin_cluster_uuid=${encodeURIComponent(confObj.cluster_uuid)}`;
+                    const clusterLink = Nav.buildUIUrl(collection, ['search', 'files']) + `?bin_cluster_uuid=${encodeURIComponent(confObj.cluster_uuid)}`;
                     return `<a href="${clusterLink}" class="stat-badge" style="background: rgba(255,255,255,0.02); display: inline-flex; margin: 2px 4px 2px 0; text-decoration: none; transition: background 0.2s;" onclick="event.preventDefault(); Nav.openPath('${clusterLink}', event);"><span style="color: #ccc; font-family: 'JetBrains Mono', 'Consolas', monospace;">${k}</span> <span class="val" style="margin-left: 4px; color: ${confColor};">${confScore}%</span></a>`;
                 }).join('');
                 return `


### PR DESCRIPTION
## Problem
Clicking an **Inferred Metadata** badge on a file viewed inside a pool redirected to the *collection* files search view, dropping out of the pool.

## Root cause
`file_view.js` built the badge href by hand as `/collections/<collection>/files?bin_cluster_uuid=...`, bypassing `Nav.buildUIUrl`. Every other cluster link (e.g. `openClusterFiles`) and the legacy `file/index.html` go through `buildUIUrl`, which is pool-aware. The refactor into `file_view.js` regressed this one link.

## Fix
One line: use `Nav.buildUIUrl(collection, ['search', 'files'])` — same call `openClusterFiles` already uses — so the link resolves to the pool files search when in a pool, and the collection files search otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)