### PR TITLE
fix(bench): pool bench uploads to wrong endpoint, triggers Ghidra

### DIFF
--- a/bsimvis/app/static/js/binary_similarity.js
+++ b/bsimvis/app/static/js/binary_similarity.js
@@ -117,7 +117,7 @@ function renderBinarySimilarityView(params) {
                 <div class="resizable-card" style="border:1px solid var(--border); border-radius:8px; display:flex; flex-direction:column; height:350px; min-height:200px; overflow:hidden; flex-shrink:0;">
                     <h3 style="margin:0; padding:15px; background:rgba(255,255,255,0.03); border-bottom:1px solid var(--border); color:var(--success);">Matched Clusters</h3>
                     <div style="flex:1; overflow:auto;">
-                        <table style="width:100%; border-collapse:collapse; font-size:0.8rem;">
+                        <table id="bin-sim-table-matched-table" style="width:100%; border-collapse:collapse; font-size:0.8rem;">
                             <thead style="position:sticky; top:0; background:var(--card-bg); z-index:10;">
                                 <!-- Rendered dynamically -->
                             </thead>
@@ -134,7 +134,7 @@ function renderBinarySimilarityView(params) {
                         <div style="flex:1; border:1px solid var(--border); border-radius:8px; display:flex; flex-direction:column; overflow:hidden;">
                             <h3 style="margin:0; padding:15px; background:rgba(255,255,255,0.03); border-bottom:1px solid var(--border); color:var(--accent);">Unmatched to Binary A</h3>
                             <div style="flex:1; overflow:auto;">
-                                <table style="width:100%; border-collapse:collapse; font-size:0.8rem;">
+                                <table id="bin-sim-table-unique-a-table" style="width:100%; border-collapse:collapse; font-size:0.8rem;">
                                     <thead style="position:sticky; top:0; background:var(--card-bg); z-index:10;">
                                         <!-- Rendered dynamically -->
                                     </thead>
@@ -146,7 +146,7 @@ function renderBinarySimilarityView(params) {
                         <div style="flex:1; border:1px solid var(--border); border-radius:8px; display:flex; flex-direction:column; overflow:hidden;">
                             <h3 style="margin:0; padding:15px; background:rgba(255,255,255,0.03); border-bottom:1px solid var(--border); color:var(--accent);">Unmatched to Binary B</h3>
                             <div style="flex:1; overflow:auto;">
-                                <table style="width:100%; border-collapse:collapse; font-size:0.8rem;">
+                                <table id="bin-sim-table-unique-b-table" style="width:100%; border-collapse:collapse; font-size:0.8rem;">
                                     <thead style="position:sticky; top:0; background:var(--card-bg); z-index:10;">
                                         <!-- Rendered dynamically -->
                                     </thead>
@@ -167,6 +167,12 @@ function renderBinarySimilarityView(params) {
             }
             .drag-handle-v:hover div {
                 background: var(--accent) !important;
+            }
+            #bin-sim-table-matched-table td,
+            #bin-sim-table-unique-a-table td,
+            #bin-sim-table-unique-b-table td {
+                position: relative;
+                user-select: text !important;
             }
         </style>
     `;
@@ -1242,6 +1248,14 @@ function renderBinSimTables(isFilterChange = false) {
                     similarityHtml = `<span class="mono" style="color:var(--accent); font-weight:bold;">${(m.cohesion * 100).toFixed(1)}%</span>`;
                 }
 
+                const clusterData = [{
+                    cluster_id: m.cluster_id,
+                    cluster_uuid: m.cluster_uuid,
+                    cluster_name: m.cluster_name,
+                    cohesion_score: m.cohesion || 1.0,
+                    member_count: 1
+                }];
+
                 return `
                 <tr style="border-bottom:1px solid rgba(255,255,255,0.05);"
                     data-entity-data='${JSON.stringify({
@@ -1281,14 +1295,8 @@ function renderBinSimTables(isFilterChange = false) {
                     <td style="padding:10px;">
                         <div class="mono dim">${(m.avg_features || 0).toFixed(1)}</div>
                     </td>
-                    <td style="padding:10px;">
-                        ${EntityRenderer.renderClusterCard([{
-                            cluster_id: m.cluster_id,
-                            cluster_uuid: m.cluster_uuid,
-                            cluster_name: m.cluster_name,
-                            cohesion_score: m.cohesion || 1.0,
-                            member_count: 1 // ponytail: simple placeholder count for matched pairs card
-                        }])}
+                    <td class="cluster-cards-cell" data-clusters='${JSON.stringify(clusterData).replace(/'/g, "&apos;")}' style="padding:10px;">
+                        ${EntityRenderer.renderClusterCard(clusterData)}
                     </td>
                 </tr>
                 `;
@@ -1359,6 +1367,13 @@ function renderBinSimTables(isFilterChange = false) {
                 const fObj = buildFuncObj(fid);
                 return `<div style="min-height:24px; display:flex; align-items:center; justify-content:center;">${EntityRenderer.renderNoteButton(fid, fObj.note_owners, { isTable: true, raw_data: fObj })}</div>`;
             }).join('');
+            const clusterData = (u.cluster_id || u.cluster_uuid) ? [{
+                cluster_id: u.cluster_id,
+                cluster_uuid: u.cluster_uuid,
+                cluster_name: u.cluster_name,
+                cohesion_score: u.cohesion || 1.0,
+                member_count: 1
+            }] : [];
             return `
             <tr style="border-bottom:1px solid rgba(255,255,255,0.05);"
                 data-entity-data='${JSON.stringify({
@@ -1381,14 +1396,8 @@ function renderBinSimTables(isFilterChange = false) {
                 <td style="padding:10px;">
                     <span class="dim">${(u.avg_features || 0).toFixed(0)}</span>
                 </td>
-                <td style="padding:10px;">
-                    ${(u.cluster_id || u.cluster_uuid) ? EntityRenderer.renderClusterCard([{
-                        cluster_id: u.cluster_id,
-                        cluster_uuid: u.cluster_uuid,
-                        cluster_name: u.cluster_name,
-                        cohesion_score: u.cohesion || 1.0,
-                        member_count: 1
-                    }]) : ''}
+                <td class="cluster-cards-cell" data-clusters='${JSON.stringify(clusterData).replace(/'/g, "&apos;")}' style="padding:10px;">
+                    ${clusterData.length > 0 ? EntityRenderer.renderClusterCard(clusterData) : ''}
                 </td>
             </tr>
             `;
@@ -1397,6 +1406,12 @@ function renderBinSimTables(isFilterChange = false) {
 
     renderUnique(data.diff.unique_to_a, document.getElementById('bin-sim-table-unique-a'), binSimSortState.uniqueA, 'ua');
     renderUnique(data.diff.unique_to_b, document.getElementById('bin-sim-table-unique-b'), binSimSortState.uniqueB, 'ub');
+
+    if (typeof TableSelection !== 'undefined') {
+        new TableSelection('bin-sim-table-matched-table');
+        new TableSelection('bin-sim-table-unique-a-table');
+        new TableSelection('bin-sim-table-unique-b-table');
+    }
 
     renderBinaryDiffSankey(data);
 }

--- a/bsimvis/app/static/js/table_selection.js
+++ b/bsimvis/app/static/js/table_selection.js
@@ -5,6 +5,10 @@ class TableSelection {
     constructor(tableId) {
         this.table = document.getElementById(tableId);
         if (!this.table) return;
+        if (this.table.tableSelectionInstance) {
+            return this.table.tableSelectionInstance;
+        }
+        this.table.tableSelectionInstance = this;
 
         this.tbody = this.table.querySelector('tbody');
         this.selectedCells = new Set(); // Stores "row:col"
@@ -572,14 +576,15 @@ class TableSelection {
         let headerLine = null;
         if (includeHeaders && Object.keys(rowColsMap).length > 0) {
             headerLine = [];
-            const thead = document.getElementById('table-head');
+            const thead = this.table.querySelector('thead');
             const headerRow = thead ? thead.querySelector('tr') : null;
             const firstRowIndex = Object.keys(rowColsMap).map(Number).sort((a, b) => a - b)[0];
             const cols = rowColsMap[firstRowIndex] || [];
 
             cols.forEach(c => {
                 const thEl = headerRow ? headerRow.children[c] : null;
-                const label = thEl ? (thEl.getAttribute('data-label') || thEl.textContent.trim()) : `Col ${c}`;
+                let label = thEl ? (thEl.getAttribute('data-label') || thEl.textContent.trim()) : `Col ${c}`;
+                label = label.replace(/[▼▲↕]/g, '').trim();
 
                 if (isSimilarityTable) {
                     if (c === 0) {

--- a/bsimvis/cli/bsimvis_bench.py
+++ b/bsimvis/cli/bsimvis_bench.py
@@ -441,31 +441,27 @@ def run_single_file_for_pool(
     size_mb, lines = get_file_stats(path)
 
     try:
-        with open(path, "rb") as fh:
-            raw = fh.read()
-        params = {
-            "collection": collection,
-            "file_name": os.path.basename(path),
-            "batch_name": "Benchmark Pool",
-            "profile": "fast",
-            "min_func_len": 10,
-            "skip_sim": "true",  # pool handles it
-        }
+        # Files are already-analyzed Ghidra JSON, so ingest via upload_file_data
+        # (pre-analyzed path). Posting raw bytes to /file/upload triggers a Ghidra
+        # analyze job that fails with "No load spec found".
+        with open(path, "r") as fh:
+            data = json.load(fh)
+
+        data["collection"] = collection
+        data["skip_sim"] = True  # pool handles similarity
         if top_k is not None:
-            params["top_k"] = top_k
+            data["top_k"] = top_k
         if min_score is not None:
-            params["min_score"] = min_score
+            data["min_score"] = min_score
         if min_features is not None:
-            params["min_features"] = min_features
+            data["min_features"] = min_features
 
         print(f"\n[*] Processing {filename} -> Collection: {collection}")
         print(f"    - Size: {size_mb:.2f} MB | Lines: {lines:,}")
 
         resp = requests.post(
-            f"{API_BASE}/file/upload",
-            params=params,
-            data=raw,
-            headers={"Content-Type": "application/octet-stream"},
+            f"{API_BASE}/file/upload_file_data",
+            json=data,
             timeout=60,
         )
         resp.raise_for_status()


### PR DESCRIPTION
## Problem

`bsimvis-bench --bench-pools` fails ingesting already-analyzed JSON:

```
Analysis failed: ghidra.app.util.opinion.LoadException: No load spec found
```

## Cause

`run_single_file_for_pool` posted the pre-analyzed Ghidra JSON as **raw bytes** to `/api/file/upload` (`upload_raw_binary`), which unconditionally queues a `GHIDRA_ANALYZE` job. Ghidra then tries to load the JSON as a binary → `No load spec found`.

The standard (non-pool) bench path already does this correctly via `/api/file/upload_file_data`.

## Fix

Pool path now posts the JSON body to `/api/file/upload_file_data` (pre-analyzed ingest) with `skip_sim=true` (pool handles similarity), matching `run_single_file`. Dropped the Ghidra-only params (`profile`, `min_func_len`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)