### PR TITLE
fix(file): consistent function renderer in file functions tab

### DIFF
--- a/bsimvis/app/static/file/index.html
+++ b/bsimvis/app/static/file/index.html
@@ -406,24 +406,12 @@
                 const cls = (f.clusters || []).map(uuid => clusters[uuid]).filter(Boolean);
                 const clusterCardHtml = window.EntityRenderer ? window.EntityRenderer.renderClusterCard(cls) : '';
 
-                // Details URL
-                let poolId = null;
-                if (window.getRoutingState && window.getRoutingState().pool) {
-                    poolId = window.getRoutingState().pool;
-                }
-                let detailUrl = `/collections/${encodeURIComponent(fColl)}/files/${file_md5}/functions/${entry}`;
-                if (poolId) {
-                    detailUrl = `/pools/${encodeURIComponent(poolId)}` + detailUrl;
-                }
-
                 return `
                     <tr class="sim-row" style="font-size: 0.75rem;" data-id="${funcId}"
                         data-entity-data='${JSON.stringify(f).replace(/'/g, "&apos;")}'
                         oncontextmenu="typeof EntityRenderer !== 'undefined' && EntityRenderer.handleContextMenu(event, 'function', this)">
-                        <td>
-                            <a href="${detailUrl}" onclick="event.preventDefault(); (window.Nav || window.parent.Nav).openPath('${detailUrl}', event);" style="color:var(--accent); font-weight:bold; text-decoration:none;">
-                                ${funcName}
-                            </a>
+                        <td style="min-width: 300px;">
+                            ${window.EntityRenderer ? window.EntityRenderer.renderFunction(f, { hideNote: true }) : funcName}
                         </td>
                         <td class="mono" style="color:var(--accent);">@ ${entry}</td>
                         <td>${tagsHtml}</td>


### PR DESCRIPTION
## What
File view **Functions** tab hand-rolled the function name cell (plain accent anchor), so it looked different from the normal function search table.

Now it renders the name cell with `EntityRenderer.renderFunction(f, { hideNote: true })` — the same renderer the search table uses. Same API (`/api/function/search`), same tooltips, colors, and function name/namespace/return-type/params formatting.

Kept out (as requested): filename, md5, file tags, language, date columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)