### PR TITLE
fix(upload): inject --metadata on streaming analysis path

### DIFF
--- a/bsimvis/worker.py
+++ b/bsimvis/worker.py
@@ -212,6 +212,19 @@ class Worker:
             job_id=job_id,
         )
         file_meta = next(generator)
+
+        # Merge CLI-provided metadata (upload --metadata) into the file metadata so
+        # it gets stored just like the `metadata propagate` path. The raw-upload
+        # route forwards it as file_metadata_extra; without this the streaming
+        # analysis path silently drops it.
+        extra_meta = payload.get("file_metadata_extra")
+        if extra_meta:
+            if isinstance(extra_meta, str):
+                extra_meta = json.loads(extra_meta)
+            file_meta.update(extra_meta)
+            if "file_name" in extra_meta:
+                file_meta["file_name"] = extra_meta["file_name"]
+
         file_md5 = file_meta.get("file_md5")
 
         # Look-ahead: send each chunk immediately without buffering all of them.


### PR DESCRIPTION
## Problem
`bsimvis upload --metadata` did not ingest metadata, while `bsimvis metadata propagate` did.

## Root cause
CLI raw-upload sends metadata as `file_metadata_extra` query param → `/api/file/upload` stores it in `analysis_payload` → passed to the `GHIDRA_ANALYZE` worker. On dev the analyze path was refactored to stream chunks via `_stream_program_chunks`, which builds chunk-0 `file_metadata` from Ghidra output only and **never merges `file_metadata_extra`**. main still merged it (worker.py ~L236); dev regressed.

## Fix
Merge `payload["file_metadata_extra"]` into `file_meta` before posting chunk 0, mirroring main's pre-refactor behavior (incl. `file_name` override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)