### PR TITLE
Avoid Lua full-set reads for unfiltered function lists

### DIFF
--- a/bsimvis/app/routes/search_function.py
+++ b/bsimvis/app/routes/search_function.py
@@ -14,6 +14,26 @@ DEFAULT_POOL_LIMIT = 1000000
 MAX_POOL_LIMIT = 1000000
 
 
+def _sscan_page(r, key, offset, limit):
+    cursor = 0
+    seen = 0
+    doc_ids = []
+    scan_count = max(100, min(1000, offset + limit))
+
+    while True:
+        cursor, batch = r.sscan(key, cursor=cursor, count=scan_count)
+        for doc_id in batch:
+            if seen >= offset and len(doc_ids) < limit:
+                doc_ids.append(doc_id)
+            seen += 1
+            if len(doc_ids) >= limit:
+                break
+        if cursor == 0 or len(doc_ids) >= limit:
+            break
+
+    return doc_ids
+
+
 def search_functions():
     try:
         t_req_start = time.perf_counter()
@@ -403,31 +423,51 @@ def search_functions():
                 }
             )
 
-        # Lua Exec
-        search_script = lua_manager.get_script("search_function")
-        if not search_script:
-            # Fallback to manual reload if script not found (first time)
-            lua_manager.register_all()
+        if not groups_raw:
+            all_key = f"{col}:all_functions"
+            total = r.scard(all_key)
+            pool_truncated = False
+
+            if sort_by != "id":
+                sort_key = f"{col}:idx:func:{sort_by}"
+                sorted_total = r.zcard(sort_key)
+                if sorted_total:
+                    total = sorted_total
+                    doc_ids = (
+                        r.zrevrange(sort_key, offset, offset + limit - 1)
+                        if sort_order == "desc"
+                        else r.zrange(sort_key, offset, offset + limit - 1)
+                    )
+                else:
+                    doc_ids = _sscan_page(r, all_key, offset, limit)
+            else:
+                doc_ids = _sscan_page(r, all_key, offset, limit)
+        else:
+            # Lua Exec
             search_script = lua_manager.get_script("search_function")
+            if not search_script:
+                # Fallback to manual reload if script not found (first time)
+                lua_manager.register_all()
+                search_script = lua_manager.get_script("search_function")
 
-        lua_config = {
-            "collection": col,
-            "pool_limit": pool_limit,
-            "groups": sorted(groups_raw, key=lambda x: x["weight"]),
-            "offset": offset,
-            "limit": limit,
-            "sort_by": sort_by,
-            "sort_order": sort_order,
-        }
+            lua_config = {
+                "collection": col,
+                "pool_limit": pool_limit,
+                "groups": sorted(groups_raw, key=lambda x: x["weight"]),
+                "offset": offset,
+                "limit": limit,
+                "sort_by": sort_by,
+                "sort_order": sort_order,
+            }
 
-        try:
-            res = search_script(keys=[], args=[json.dumps(lua_config)])
-            total = res[0]
-            pool_truncated = bool(res[1])
-            doc_ids = res[2]
-        except Exception as e:
-            logging.error(f"FUNC LUA SEARCH CRASH: {e}")
-            return {"error": str(e)}, 500
+            try:
+                res = search_script(keys=[], args=[json.dumps(lua_config)])
+                total = res[0]
+                pool_truncated = bool(res[1])
+                doc_ids = res[2]
+            except Exception as e:
+                logging.error(f"FUNC LUA SEARCH CRASH: {e}")
+                return {"error": str(e)}, 500
 
         # --- ENRICHMENT (Optimized & Deduplicated) ---
         t_enrich_start = time.perf_counter()


### PR DESCRIPTION
## Summary

Avoid routing unfiltered function list requests through the Lua search path.

When the Functions table loads without filters, the existing Lua script can fall back to reading `collection:all_functions` before pagination. In a large or partially ingested collection, this can make `/api/function/search?collection=main&limit=100&min_cohesion=0.95` time out and leave Kvrocks unresponsive.

This adds a bounded route-level path for unfiltered function list requests:

- uses `SCARD` for the total count
- uses an existing sorted function index when available
- falls back to bounded `SSCAN` for the requested page
- keeps filtered searches on the existing Lua producer/filter path

Addresses #12

## Provenance

This PR came from reproducing a Kvrocks hang while investigating the function-search dashboard path on a large/partially indexed `main` collection. The original symptom was an unfiltered function-list request timing out, followed by Kvrocks becoming unresponsive to `PING`.

The initial PR was opened against `main`, but after maintainer feedback that current stable work is on `dev`, I fetched `MISP/bsimvis` `dev` and rechecked the change there.

On current `origin/dev`, the broader build-sim Kvrocks EVAL-lock issue appears to have been addressed separately by:

```text
cd95b34 perf(sim): reimplement build-sim discovery in Python to drop kvrocks EVAL lock
```

PR #13 is therefore scoped more narrowly: it still covers the unfiltered function-search/listing path. On `origin/dev`, that path still calls `search_function.lua` with an empty `groups` list, and the Lua script still falls back to:

```lua
raw_ids = redis.call('SMEMBERS', producer.key)
```

where `producer.key` is `collection .. ":all_functions"`.

## Validation Against `dev`

I created a temporary detached worktree from `origin/dev`, cherry-picked this PR commit onto it, and verified that it applies cleanly.

Validation performed after retargeting the PR to `dev`:

- `git diff --check origin/dev..HEAD`
- `uv run python -m compileall bsimvis/app/routes/search_function.py`
- GitHub reports the retargeted PR as mergeable

I also ran a small fake-Redis route harness to verify the failure trigger without stressing a real Kvrocks instance:

- unpatched `origin/dev`: `GET /api/function/search?collection=main&limit=2` reaches Lua with `groups: []`, reproducing the risky `SMEMBERS main:all_functions` path
- patched PR branch on top of `dev`: the same request does not call Lua; it uses `SCARD main:all_functions`, bounded `SSCAN main:all_functions`, then the normal enrichment pipeline

## Implementation Notes

I initially tried keeping this entirely inside `bsimvis/app/lua/search_function.lua` by replacing the unfiltered `SMEMBERS` path with bounded Lua-side pagination. That still reproduced the failure in the isolated repro runtime: the request timed out after about 20s and Kvrocks stopped responding to `PING`.

Because of that, this PR avoids invoking the Lua search script at all for the no-filter function list case. Filtered searches still use the existing Lua producer/filter path.

## Scope

This is intentionally limited to `bsimvis/app/routes/search_function.py` and the default unfiltered function list path. It does not change the UI, storage schema, ingestion/indexing model, similarity build logic, or filtered search behavior.

## Tradeoffs

This PR intentionally avoids adding a new ordered function-list index, so there are two remaining edge cases in the fallback path:

1. **Deep pagination without a sort index may still be slower.**  
   If the request asks for a high `offset` and there is no usable sorted function index, the fallback has to scan past earlier set members before collecting the requested page. This is still bounded to page collection rather than loading the full function set into Lua, but it is not as efficient as a real ordered index.

2. **Default `sort_by=id` fallback is not globally sorted.**  
   `collection:all_functions` is a set, so `SSCAN` does not provide stable global ordering. The fallback returns a bounded page of function IDs, but it does not reproduce the old behavior of loading and sorting the entire set by ID. Preserving stable ID ordering efficiently would require a maintained ordered function-list index.

A future follow-up could add/backfill such an index, but that would touch ingestion/indexing behavior, so I left it out to keep this PR focused on the reproduced Kvrocks hang.

## Testing

- `luac -p bsimvis/app/lua/search_function.lua`
- `PYTHONPYCACHEPREFIX=/tmp/bsimvis-pycache uv run python -m py_compile bsimvis/app/routes/search_function.py`
- `git diff --check origin/main...HEAD`
- Verified against the original isolated repro runtime:
  - before fix: request timed out after about 20s and Kvrocks `PING` hung
  - Lua-side pagination attempt: still timed out after about 20s and Kvrocks `PING` hung
  - after this route-level fix: request returned `HTTP 200 total 0.014008`
  - post-request Kvrocks `PING` returned `PONG`
- Revalidated after retargeting to `dev`:
  - cherry-pick onto temporary `origin/dev` worktree applied cleanly
  - `git diff --check origin/dev..HEAD`
  - `uv run python -m compileall bsimvis/app/routes/search_function.py`
  - fake-Redis harness confirmed unpatched `dev` reaches the unfiltered Lua path and patched `dev` avoids it
