### PR TITLE
fix(cluster): exclude shed noise points from cluster membership

### DIFF
--- a/bsimvis/app/services/bin_cluster_service.py
+++ b/bsimvis/app/services/bin_cluster_service.py
@@ -408,17 +408,13 @@ class BinClusterService:
         if job_service and job_id:
             job_service.add_log(job_id, "Extracting hierarchical clusters from tree...")
 
-        child_to_parent = dict(zip(tree_df["child"], tree_df["parent"]))
+        # Map leaves to the clusters they actually survive into (shed noise
+        # points excluded). See cluster_common.hierarchical_membership.
+        from bsimvis.app.services.cluster_common import hierarchical_membership
 
-        leaf_to_clusters = {}
-        for leaf in range(num_nodes):
-            clusters = set()
-            curr = leaf
-            while curr in child_to_parent:
-                p = child_to_parent[curr]
-                clusters.add(int(p))
-                curr = p
-            leaf_to_clusters[leaf] = list(clusters)
+        leaf_to_clusters, leaf_home = hierarchical_membership(
+            tree_df, num_nodes, global_root_id, min_size=min_cluster_size
+        )
 
         cluster_members = {}
         for leaf, clusters in leaf_to_clusters.items():
@@ -463,17 +459,12 @@ class BinClusterService:
                 pipe.execute()
         pipe.execute()
 
-        # Extract and save direct members (where child_size == 1)
+        # Direct members = leaves whose deepest surviving cluster is this node
+        # (shed noise points excluded, matching the membership rule above).
         direct_members = {}
-        for _, row in tree_df.iterrows():
-            if int(row["child_size"]) == 1:
-                p = int(row["parent"])
-                leaf = int(row["child"])
-                if leaf in idx_to_id:
-                    fid = idx_to_id[leaf]
-                    if p not in direct_members:
-                        direct_members[p] = []
-                    direct_members[p].append(fid)
+        for leaf, p in leaf_home.items():
+            if leaf in idx_to_id:
+                direct_members.setdefault(p, []).append(idx_to_id[leaf])
 
         for c, d_members in direct_members.items():
             pipe.sadd(f"{collection}:bin_cluster:{algo}:{c}:direct_members", *d_members)

--- a/bsimvis/app/services/cluster_common.py
+++ b/bsimvis/app/services/cluster_common.py
@@ -1,0 +1,120 @@
+"""Shared helpers for function/binary hierarchical clustering."""
+
+
+def hierarchical_membership(tree_df, num_nodes, global_root_id, min_size=2):
+    """Map leaves to the condensed-tree clusters they actually belong to.
+
+    A leaf belongs to an ancestor cluster C only if it *survives* down to C's
+    death lambda (``fallout(leaf) >= death(C)``). Points that shed as singleton
+    noise before C dissolves — e.g. a loosely-attached binary peeling off a tight
+    pair — are NOT members of C. Without this rule the shed points dilute the
+    tight core, so a 100%-similar pair shows up as one low-cohesion cluster of 3
+    instead of a precise pair.
+
+    The synthetic global root (which only stitches unrelated connected components
+    together) is never treated as a cluster.
+
+    Args:
+        tree_df: pandas DataFrame with columns parent, child, lambda_val, child_size
+                 (the final, post-prune condensed tree).
+        num_nodes: number of leaf nodes (leaves are ids 0..num_nodes-1).
+        global_root_id: id of the synthetic global root to exclude.
+
+    Returns:
+        (leaf_to_clusters, leaf_home)
+          leaf_to_clusters: {leaf: [cluster_id, ...]}  (all surviving ancestors)
+          leaf_home:        {leaf: deepest_cluster_id}  (its own cluster; absent if noise)
+    """
+    child_to_parent = dict(zip(tree_df["child"], tree_df["parent"]))
+
+    death = {}
+    leaf_fall = {}
+    for _, row in tree_df.iterrows():
+        p = int(row["parent"])
+        l = float(row["lambda_val"])
+        if l > death.get(p, 0.0):
+            death[p] = l
+        if int(row["child_size"]) == 1:
+            leaf_fall[int(row["child"])] = l
+
+    # First pass: surviving ancestors per leaf, ordered deepest-first.
+    survived = {}
+    counts = {}
+    for leaf in range(num_nodes):
+        chain = []
+        curr = leaf
+        fall = leaf_fall.get(leaf, float("inf"))
+        while curr in child_to_parent:
+            p = int(child_to_parent[curr])
+            if p != global_root_id and fall >= death.get(p, 0.0):
+                chain.append(p)
+                counts[p] = counts.get(p, 0) + 1
+            curr = p
+        survived[leaf] = chain
+
+    # Drop nodes that ended up with fewer than min_size survivors — a "cluster"
+    # of one is just noise once its neighbours shed.
+    valid = {c for c, n in counts.items() if n >= min_size}
+
+    leaf_to_clusters = {}
+    leaf_home = {}
+    for leaf, chain in survived.items():
+        kept = [c for c in chain if c in valid]  # deepest-first
+        leaf_to_clusters[leaf] = kept
+        if kept:
+            leaf_home[leaf] = kept[0]
+
+    return leaf_to_clusters, leaf_home
+
+
+def _demo():
+    """Self-check against real HDBSCAN condensed trees (no Redis needed)."""
+    import numpy as np
+    import hdbscan
+    import pandas as pd
+
+    def run(sim):
+        d = 1.0 - np.array(sim)
+        c = hdbscan.HDBSCAN(
+            min_cluster_size=2,
+            min_samples=1,
+            metric="precomputed",
+            gen_min_span_tree=True,
+            allow_single_cluster=True,
+        )
+        c.fit(d.astype(np.float64))
+        t = c.condensed_tree_.to_pandas()
+        n = len(sim)
+        # No synthetic root in this single-component test; pass a sentinel id.
+        l2c, home = hierarchical_membership(t, n, global_root_id=-999)
+        members = {}
+        for leaf, cs in l2c.items():
+            for cid in cs:
+                members.setdefault(cid, set()).add(leaf)
+        return members, home
+
+    # S1: A,B identical (.98), C only .75 -> tight pair {0,1}, C shed as noise.
+    m, home = run([[1, 0.98, 0.75], [0.98, 1, 0.75], [0.75, 0.75, 1]])
+    sets = sorted(sorted(v) for v in m.values())
+    assert sets == [[0, 1]], f"S1 expected one tight pair, got {sets}"
+    assert 2 not in home, f"C should be noise, home={home}"
+
+    # S2: two genuine families -> full hierarchy preserved (parent + two children).
+    s2 = [
+        [1, 0.98, 0.98, 0.75, 0.75, 0.75],
+        [0.98, 1, 0.98, 0.75, 0.75, 0.75],
+        [0.98, 0.98, 1, 0.75, 0.75, 0.75],
+        [0.75, 0.75, 0.75, 1, 0.98, 0.98],
+        [0.75, 0.75, 0.75, 0.98, 1, 0.98],
+        [0.75, 0.75, 0.75, 0.98, 0.98, 1],
+    ]
+    m, home = run(s2)
+    sets = sorted(sorted(v) for v in m.values())
+    assert [0, 1, 2] in sets and [3, 4, 5] in sets, f"missing tight families: {sets}"
+    assert [0, 1, 2, 3, 4, 5] in sets, f"missing parent level: {sets}"
+
+    print("hierarchical_membership demo OK")
+
+
+if __name__ == "__main__":
+    _demo()

--- a/bsimvis/app/services/cluster_service.py
+++ b/bsimvis/app/services/cluster_service.py
@@ -456,18 +456,13 @@ class ClusterService:
         if job_service and job_id:
             job_service.add_log(job_id, "Extracting hierarchical clusters from tree...")
 
-        # Build tree traversal mapping
-        child_to_parent = dict(zip(tree_df["child"], tree_df["parent"]))
+        # Map leaves to the clusters they actually survive into (shed noise
+        # points excluded). See cluster_common.hierarchical_membership.
+        from bsimvis.app.services.cluster_common import hierarchical_membership
 
-        leaf_to_clusters = {}
-        for leaf in range(num_nodes):
-            clusters = set()
-            curr = leaf
-            while curr in child_to_parent:
-                p = child_to_parent[curr]
-                clusters.add(int(p))
-                curr = p
-            leaf_to_clusters[leaf] = list(clusters)
+        leaf_to_clusters, leaf_home = hierarchical_membership(
+            tree_df, num_nodes, global_root_id, min_size=min_cluster_size
+        )
 
         # Reverse map to find cluster members
         cluster_members = {}
@@ -518,17 +513,12 @@ class ClusterService:
                 pipe.execute()
         pipe.execute()
 
-        # Extract and save direct members (where child_size == 1)
+        # Direct members = leaves whose deepest surviving cluster is this node
+        # (shed noise points are excluded, matching the membership rule above).
         direct_members = {}
-        for _, row in tree_df.iterrows():
-            if int(row["child_size"]) == 1:
-                p = int(row["parent"])
-                leaf = int(row["child"])
-                if leaf in idx_to_id:
-                    fid = idx_to_id[leaf]
-                    if p not in direct_members:
-                        direct_members[p] = []
-                    direct_members[p].append(fid)
+        for leaf, p in leaf_home.items():
+            if leaf in idx_to_id:
+                direct_members.setdefault(p, []).append(idx_to_id[leaf])
 
         for c, d_members in direct_members.items():
             pipe.sadd(f"{collection}:cluster:{algo}:{c}:direct_members", *d_members)


### PR DESCRIPTION
## Problem
Two complaints, one root cause:
1. **Cluster metadata wrong** — `member_count`, `cohesion_score` etc inflated.
2. **Big low-cohesion clusters instead of small precise ones** — e.g. 3 binaries where 2 are 100% similar land in one ~80%-cohesion cluster of 3.

## Root cause
HDBSCAN's condensed tree keeps a tight core under one node while loosely-attached members **peel off one-at-a-time as singleton noise** (each < `min_cluster_size`), so no bifurcation node is created. The code then built each node's membership by walking **every descendant leaf** — including those shed singletons. Result: the tight `{A,B}` core got diluted with the loosely-attached `C`, showing as one low-cohesion cluster of 3, with `member_count`/`cohesion` counting the shed point.

This is *not* a parameter problem — `min_samples=1` (needed to keep identical binaries tight) is already the default. It's a membership-extraction bug.

## Fix
A leaf belongs to an ancestor cluster `C` only if it **survives to `C`'s death lambda** (`fallout(leaf) >= death(C)`). Shed points drop out and become noise.
- Genuine sub-structure is untouched: parent + tight child clusters are still all emitted (verified).
- Excludes the synthetic global root (only stitches unrelated connected components — was producing a giant ~0-cohesion cluster).
- Drops degenerate `< min_cluster_size` survivor nodes.
- `direct_members` now derived from each leaf's deepest surviving cluster, so it can't list a point the cluster no longer counts.

Shared logic in `cluster_common.hierarchical_membership`, applied to both function and binary clustering, with a Redis-free self-check (`uv run python bsimvis/app/services/cluster_common.py`) that asserts:
- tight pair `{A,B}` + loose `C` → pair only, `C` noise;
- two genuine families → full hierarchy preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)