### PR TITLE
fix(cluster): exclude shed noise points from cluster membership

### DIFF
--- a/bsimvis/app/routes/cluster.py
+++ b/bsimvis/app/routes/cluster.py
@@ -34,6 +34,15 @@ def build_cluster():
         "min_features": data.get(
             "min_features", config_service.get("clustering.min_features", 0)
         ),
+        "algorithm": data.get(
+            "algorithm", config_service.get("clustering.algorithm", "hdbscan")
+        ),
+        "resolution": data.get(
+            "resolution", config_service.get("clustering.resolution", 1.0)
+        ),
+        "stop_cohesion": data.get(
+            "stop_cohesion", config_service.get("clustering.stop_cohesion", 0.9)
+        ),
     }
 
     job_id = job_service.create_job(JobType.CLUSTER_FUNCTIONS, payload)
@@ -79,6 +88,16 @@ def rebuild_cluster():
                 "min_features": data.get(
                     "min_features", config_service.get("clustering.min_features", 0)
                 ),
+                "algorithm": data.get(
+                    "algorithm", config_service.get("clustering.algorithm", "hdbscan")
+                ),
+                "resolution": data.get(
+                    "resolution", config_service.get("clustering.resolution", 1.0)
+                ),
+                "stop_cohesion": data.get(
+                    "stop_cohesion",
+                    config_service.get("clustering.stop_cohesion", 0.9),
+                ),
             },
         ),
     ]
@@ -121,6 +140,16 @@ def rebuild_all_pipeline():
                 ),
                 "min_features": data.get(
                     "min_features", config_service.get("clustering.min_features", 0)
+                ),
+                "algorithm": data.get(
+                    "algorithm", config_service.get("clustering.algorithm", "hdbscan")
+                ),
+                "resolution": data.get(
+                    "resolution", config_service.get("clustering.resolution", 1.0)
+                ),
+                "stop_cohesion": data.get(
+                    "stop_cohesion",
+                    config_service.get("clustering.stop_cohesion", 0.9),
                 ),
             },
         ),

--- a/bsimvis/app/services/bin_cluster_service.py
+++ b/bsimvis/app/services/bin_cluster_service.py
@@ -408,17 +408,13 @@ class BinClusterService:
         if job_service and job_id:
             job_service.add_log(job_id, "Extracting hierarchical clusters from tree...")
 
-        child_to_parent = dict(zip(tree_df["child"], tree_df["parent"]))
+        # Map leaves to the clusters they actually survive into (shed noise
+        # points excluded). See cluster_common.hierarchical_membership.
+        from bsimvis.app.services.cluster_common import hierarchical_membership
 
-        leaf_to_clusters = {}
-        for leaf in range(num_nodes):
-            clusters = set()
-            curr = leaf
-            while curr in child_to_parent:
-                p = child_to_parent[curr]
-                clusters.add(int(p))
-                curr = p
-            leaf_to_clusters[leaf] = list(clusters)
+        leaf_to_clusters, leaf_home = hierarchical_membership(
+            tree_df, num_nodes, global_root_id, min_size=min_cluster_size
+        )
 
         cluster_members = {}
         for leaf, clusters in leaf_to_clusters.items():
@@ -463,17 +459,12 @@ class BinClusterService:
                 pipe.execute()
         pipe.execute()
 
-        # Extract and save direct members (where child_size == 1)
+        # Direct members = leaves whose deepest surviving cluster is this node
+        # (shed noise points excluded, matching the membership rule above).
         direct_members = {}
-        for _, row in tree_df.iterrows():
-            if int(row["child_size"]) == 1:
-                p = int(row["parent"])
-                leaf = int(row["child"])
-                if leaf in idx_to_id:
-                    fid = idx_to_id[leaf]
-                    if p not in direct_members:
-                        direct_members[p] = []
-                    direct_members[p].append(fid)
+        for leaf, p in leaf_home.items():
+            if leaf in idx_to_id:
+                direct_members.setdefault(p, []).append(idx_to_id[leaf])
 
         for c, d_members in direct_members.items():
             pipe.sadd(f"{collection}:bin_cluster:{algo}:{c}:direct_members", *d_members)

--- a/bsimvis/app/services/cluster_common.py
+++ b/bsimvis/app/services/cluster_common.py
@@ -1,6 +1,143 @@
 """Shared helpers for function/binary hierarchical clustering."""
 
 
+def _adjacency(edges):
+    """edges: list of (i, j, dist). Returns {node: {nbr: sim}} with sim = 1 - dist."""
+    adj = {}
+    for i, j, d in edges:
+        s = 1.0 - d
+        adj.setdefault(i, {})[j] = s
+        adj.setdefault(j, {})[i] = s
+    return adj
+
+
+def _cohesion(members, adj):
+    """Average pairwise similarity over all member pairs (missing pair = 0)."""
+    m = list(members)
+    k = len(m)
+    if k < 2:
+        return 1.0
+    tot = 0.0
+    for a in range(k):
+        nb = adj.get(m[a], {})
+        for b in range(a + 1, k):
+            tot += nb.get(m[b], 0.0)
+    return tot / (k * (k - 1) / 2.0)
+
+
+def build_leiden_tree(
+    edges,
+    num_nodes,
+    resolution=1.0,
+    stop_cohesion=0.9,
+    min_size=2,
+    job_service=None,
+    job_id=None,
+):
+    """Recursive-Leiden hierarchy in the same condensed-tree shape HDBSCAN emits.
+
+    Each connected component is clustered with Leiden, then each community is
+    recursively re-clustered until it is either tight enough (cohesion >=
+    ``stop_cohesion``), too small, or can no longer be split. This yields a
+    strict nested tree: coarse low-cohesion parents on top (dendrogram insight),
+    tight high-cohesion groups at the leaves (the sub-groups HDBSCAN's
+    single-linkage buries). Points that never join a >=2 group stay direct
+    members of their parent (i.e. not force-split into arbitrary pairs).
+
+    Lambda is depth-based (child edge lambda = parent_depth + 1), which makes
+    every leaf survive to all of its ancestors under
+    ``hierarchical_membership`` — Leiden hierarchies have no shed-noise, so the
+    membership rule keeps the full ancestor chain.
+
+    Returns (tree_df, global_root_id) — a pandas DataFrame with columns
+    parent, child, lambda_val, child_size, ready to flow through the same
+    persistence path as the HDBSCAN tree.
+    """
+    import igraph as ig
+    import leidenalg as la
+    import pandas as pd
+
+    adj = _adjacency(edges)
+    global_root_id = num_nodes
+    next_id = [num_nodes + 1]
+    rows = []
+
+    def leiden_split(members):
+        idx = {g: i for i, g in enumerate(members)}
+        es, w = [], []
+        for a in members:
+            for b, s in adj.get(a, {}).items():
+                if b in idx and idx[a] < idx[b]:
+                    es.append((idx[a], idx[b]))
+                    w.append(s)
+        g = ig.Graph(n=len(members), edges=es)
+        g.es["weight"] = w
+        part = la.RBConfigurationVertexPartition(
+            g, weights="weight", resolution_parameter=resolution
+        )
+        la.Optimiser().optimise_partition(part)
+        return [[members[i] for i in comm] for comm in part]
+
+    def rec(members, depth):
+        """Return (node_or_leaf_id, subtree_leaf_count); append rows for its children."""
+        if len(members) == 1:
+            return members[0], 1  # bare leaf point; parent creates the edge row
+        node_id = next_id[0]
+        next_id[0] += 1
+        subs = None
+        if len(members) >= max(2, min_size) and _cohesion(members, adj) < stop_cohesion:
+            parts = [p for p in leiden_split(members) if p]
+            if len(parts) >= 2:
+                subs = parts
+        lam = float(depth + 1)
+        if subs is None:
+            # leaf cluster: attach every member point directly
+            for leaf in members:
+                rows.append(
+                    {
+                        "parent": node_id,
+                        "child": leaf,
+                        "lambda_val": lam,
+                        "child_size": 1,
+                    }
+                )
+            return node_id, len(members)
+        total = 0
+        for part in subs:
+            cid, sz = rec(part, depth + 1)
+            rows.append(
+                {"parent": node_id, "child": cid, "lambda_val": lam, "child_size": sz}
+            )
+            total += sz
+        return node_id, total
+
+    # connected components via igraph
+    all_edges = [(i, j) for i, j, d in edges if d < 1.0]
+    g_full = ig.Graph(n=num_nodes, edges=all_edges)
+    comps = g_full.connected_components()
+
+    for comp in comps:
+        comp = list(comp)
+        cid, sz = rec(comp, 0)
+        if sz >= 1 and cid != global_root_id:
+            rows.append(
+                {
+                    "parent": global_root_id,
+                    "child": cid,
+                    "lambda_val": 0.0,
+                    "child_size": sz,
+                }
+            )
+
+    if job_service and job_id:
+        job_service.add_log(
+            job_id,
+            f"Recursive Leiden built {len(rows)} tree rows "
+            f"(resolution={resolution}, stop_cohesion={stop_cohesion}).",
+        )
+    return pd.DataFrame(rows), global_root_id
+
+
 def hierarchical_membership(tree_df, num_nodes, global_root_id, min_size=2):
     """Map leaves to the condensed-tree clusters they actually belong to.
 
@@ -116,5 +253,61 @@ def _demo():
     print("hierarchical_membership demo OK")
 
 
+def _demo_leiden():
+    """Recursive-Leiden builder: keeps low-cohesion parent, surfaces tight children."""
+    import numpy as np
+
+    def edges_from_sim(sim, thresh=0.7):
+        e = []
+        n = len(sim)
+        for i in range(n):
+            for j in range(i + 1, n):
+                s = sim[i][j]
+                if s >= thresh:  # mimic min_score store threshold
+                    e.append((i, j, 1.0 - s))
+        return e, n
+
+    def members_of(tree_df, n, groot):
+        l2c, home = hierarchical_membership(tree_df, n, groot)
+        mem = {}
+        for leaf, cs in l2c.items():
+            for cid in cs:
+                mem.setdefault(cid, set()).add(leaf)
+        return mem
+
+    # Two tight triangles joined by one weak bridge edge. The whole thing is a
+    # low-cohesion parent; each triangle is a tight child that must be surfaced.
+    s2 = [
+        [1, 0.98, 0.98, 0.00, 0.00, 0.00],
+        [0.98, 1, 0.98, 0.00, 0.00, 0.00],
+        [0.98, 0.98, 1, 0.75, 0.00, 0.00],
+        [0.00, 0.00, 0.75, 1, 0.98, 0.98],
+        [0.00, 0.00, 0.00, 0.98, 1, 0.98],
+        [0.00, 0.00, 0.00, 0.98, 0.98, 1],
+    ]
+    e, n = edges_from_sim(s2)
+    tdf, groot = build_leiden_tree(e, n, resolution=1.0, stop_cohesion=0.9, min_size=2)
+    mem = members_of(tdf, n, groot)
+    sets = sorted(sorted(v) for v in mem.values())
+    assert [0, 1, 2] in sets and [3, 4, 5] in sets, f"tight children missing: {sets}"
+    assert [0, 1, 2, 3, 4, 5] in sets, f"parent level missing (dendrogram): {sets}"
+
+    # Already-tight quad: must NOT over-split -> one cluster only.
+    s1 = [[1, 0.98, 0.97, 0.98]] * 0 + [
+        [1, 0.98, 0.97, 0.98],
+        [0.98, 1, 0.98, 0.97],
+        [0.97, 0.98, 1, 0.98],
+        [0.98, 0.97, 0.98, 1],
+    ]
+    e, n = edges_from_sim(s1)
+    tdf, groot = build_leiden_tree(e, n, resolution=1.0, stop_cohesion=0.9, min_size=2)
+    mem = members_of(tdf, n, groot)
+    sets = sorted(sorted(v) for v in mem.values())
+    assert sets == [[0, 1, 2, 3]], f"tight quad should stay one cluster, got {sets}"
+
+    print("build_leiden_tree demo OK")
+
+
 if __name__ == "__main__":
     _demo()
+    _demo_leiden()

--- a/bsimvis/app/services/cluster_common.py
+++ b/bsimvis/app/services/cluster_common.py
@@ -1,0 +1,120 @@
+"""Shared helpers for function/binary hierarchical clustering."""
+
+
+def hierarchical_membership(tree_df, num_nodes, global_root_id, min_size=2):
+    """Map leaves to the condensed-tree clusters they actually belong to.
+
+    A leaf belongs to an ancestor cluster C only if it *survives* down to C's
+    death lambda (``fallout(leaf) >= death(C)``). Points that shed as singleton
+    noise before C dissolves — e.g. a loosely-attached binary peeling off a tight
+    pair — are NOT members of C. Without this rule the shed points dilute the
+    tight core, so a 100%-similar pair shows up as one low-cohesion cluster of 3
+    instead of a precise pair.
+
+    The synthetic global root (which only stitches unrelated connected components
+    together) is never treated as a cluster.
+
+    Args:
+        tree_df: pandas DataFrame with columns parent, child, lambda_val, child_size
+                 (the final, post-prune condensed tree).
+        num_nodes: number of leaf nodes (leaves are ids 0..num_nodes-1).
+        global_root_id: id of the synthetic global root to exclude.
+
+    Returns:
+        (leaf_to_clusters, leaf_home)
+          leaf_to_clusters: {leaf: [cluster_id, ...]}  (all surviving ancestors)
+          leaf_home:        {leaf: deepest_cluster_id}  (its own cluster; absent if noise)
+    """
+    child_to_parent = dict(zip(tree_df["child"], tree_df["parent"]))
+
+    death = {}
+    leaf_fall = {}
+    for _, row in tree_df.iterrows():
+        p = int(row["parent"])
+        l = float(row["lambda_val"])
+        if l > death.get(p, 0.0):
+            death[p] = l
+        if int(row["child_size"]) == 1:
+            leaf_fall[int(row["child"])] = l
+
+    # First pass: surviving ancestors per leaf, ordered deepest-first.
+    survived = {}
+    counts = {}
+    for leaf in range(num_nodes):
+        chain = []
+        curr = leaf
+        fall = leaf_fall.get(leaf, float("inf"))
+        while curr in child_to_parent:
+            p = int(child_to_parent[curr])
+            if p != global_root_id and fall >= death.get(p, 0.0):
+                chain.append(p)
+                counts[p] = counts.get(p, 0) + 1
+            curr = p
+        survived[leaf] = chain
+
+    # Drop nodes that ended up with fewer than min_size survivors — a "cluster"
+    # of one is just noise once its neighbours shed.
+    valid = {c for c, n in counts.items() if n >= min_size}
+
+    leaf_to_clusters = {}
+    leaf_home = {}
+    for leaf, chain in survived.items():
+        kept = [c for c in chain if c in valid]  # deepest-first
+        leaf_to_clusters[leaf] = kept
+        if kept:
+            leaf_home[leaf] = kept[0]
+
+    return leaf_to_clusters, leaf_home
+
+
+def _demo():
+    """Self-check against real HDBSCAN condensed trees (no Redis needed)."""
+    import numpy as np
+    import hdbscan
+    import pandas as pd
+
+    def run(sim):
+        d = 1.0 - np.array(sim)
+        c = hdbscan.HDBSCAN(
+            min_cluster_size=2,
+            min_samples=1,
+            metric="precomputed",
+            gen_min_span_tree=True,
+            allow_single_cluster=True,
+        )
+        c.fit(d.astype(np.float64))
+        t = c.condensed_tree_.to_pandas()
+        n = len(sim)
+        # No synthetic root in this single-component test; pass a sentinel id.
+        l2c, home = hierarchical_membership(t, n, global_root_id=-999)
+        members = {}
+        for leaf, cs in l2c.items():
+            for cid in cs:
+                members.setdefault(cid, set()).add(leaf)
+        return members, home
+
+    # S1: A,B identical (.98), C only .75 -> tight pair {0,1}, C shed as noise.
+    m, home = run([[1, 0.98, 0.75], [0.98, 1, 0.75], [0.75, 0.75, 1]])
+    sets = sorted(sorted(v) for v in m.values())
+    assert sets == [[0, 1]], f"S1 expected one tight pair, got {sets}"
+    assert 2 not in home, f"C should be noise, home={home}"
+
+    # S2: two genuine families -> full hierarchy preserved (parent + two children).
+    s2 = [
+        [1, 0.98, 0.98, 0.75, 0.75, 0.75],
+        [0.98, 1, 0.98, 0.75, 0.75, 0.75],
+        [0.98, 0.98, 1, 0.75, 0.75, 0.75],
+        [0.75, 0.75, 0.75, 1, 0.98, 0.98],
+        [0.75, 0.75, 0.75, 0.98, 1, 0.98],
+        [0.75, 0.75, 0.75, 0.98, 0.98, 1],
+    ]
+    m, home = run(s2)
+    sets = sorted(sorted(v) for v in m.values())
+    assert [0, 1, 2] in sets and [3, 4, 5] in sets, f"missing tight families: {sets}"
+    assert [0, 1, 2, 3, 4, 5] in sets, f"missing parent level: {sets}"
+
+    print("hierarchical_membership demo OK")
+
+
+if __name__ == "__main__":
+    _demo()

--- a/bsimvis/app/services/cluster_service.py
+++ b/bsimvis/app/services/cluster_service.py
@@ -36,9 +36,16 @@ class ClusterService:
         min_features=None,
         job_service=None,
         job_id=None,
+        algorithm=None,
+        resolution=None,
+        stop_cohesion=None,
     ):
         """
-        Runs HDBSCAN clustering on similarity pairs stored in Kvrocks.
+        Runs clustering on similarity pairs stored in Kvrocks.
+
+        algorithm: "hdbscan" (default) or "leiden" (recursive community detection
+        on the sparse similarity graph — keeps low-cohesion parents for the
+        dendrogram while surfacing tight high-cohesion sub-groups).
         """
         from bsimvis.app.services.config_service import config_service
 
@@ -54,7 +61,14 @@ class ClusterService:
             min_sim = config_service.get("clustering.min_sim", 0.0)
         if min_features is None:
             min_features = config_service.get("clustering.min_features", 0)
-        if hdbscan is None:
+        if algorithm is None:
+            algorithm = config_service.get("clustering.algorithm", "hdbscan")
+        if resolution is None:
+            resolution = config_service.get("clustering.resolution", 1.0)
+        if stop_cohesion is None:
+            stop_cohesion = config_service.get("clustering.stop_cohesion", 0.9)
+        algorithm = str(algorithm).lower()
+        if algorithm == "hdbscan" and hdbscan is None:
             logging.error(
                 "hdbscan library not installed. Please install it to use clustering."
             )
@@ -206,252 +220,52 @@ class ClusterService:
         if job_service and job_id:
             job_service.add_log(job_id, msg)
 
-        # 3. Connected Components and Local HDBSCAN
-        import scipy.sparse as sp
-        from scipy.sparse.csgraph import connected_components
         import pandas as pd
 
-        msg = f"Shattering graph into connected components to avoid OOM..."
-        logging.info(f"[*] {msg}")
-        if job_service and job_id:
-            job_service.add_log(job_id, msg)
+        # --- algorithm dispatch: build the hierarchy (tree_df) ---------------
+        if algorithm == "leiden":
+            from bsimvis.app.services.cluster_common import build_leiden_tree
 
-        rows = []
-        cols = []
-        data = []
-        for i, j, d in edges:
-            if d < 1.0:  # Only real similarity edges
-                rows.extend([i, j])
-                cols.extend([j, i])
-                data.extend([1, 1])
-
-        adj_matrix = sp.csr_matrix((data, (rows, cols)), shape=(num_nodes, num_nodes))
-        n_components, labels = connected_components(csgraph=adj_matrix, directed=False)
-
-        comp_to_nodes = {}
-        for i, comp_id in enumerate(labels):
-            if comp_id not in comp_to_nodes:
-                comp_to_nodes[comp_id] = []
-            comp_to_nodes[comp_id].append(i)
-
-        comp_to_edges = {}
-        for i, j, d in edges:
-            c = labels[i]
-            if c == labels[j]:
-                if c not in comp_to_edges:
-                    comp_to_edges[c] = []
-                comp_to_edges[c].append((i, j, d))
-
-        msg = f"Found {n_components} connected components. Running local HDBSCAN..."
-        logging.info(f"[*] {msg}")
-        if job_service and job_id:
-            job_service.add_log(job_id, msg)
-
-        global_tree_rows = []
-        global_root_id = num_nodes
-        next_cluster_id = num_nodes + 1
-        comp_roots = []
-
-        start_fit = time.time()
-
-        for comp_id, comp_nodes in comp_to_nodes.items():
-            size = len(comp_nodes)
-            if size < min_cluster_size:
-                for node in comp_nodes:
-                    comp_roots.append((node, 1))
-                continue
-
-            sub_id_to_global = {
-                i: global_idx for i, global_idx in enumerate(comp_nodes)
-            }
-            global_to_sub_id = {
-                global_idx: i for i, global_idx in enumerate(comp_nodes)
-            }
-
-            if size >= 5000:
-                from scipy.sparse.linalg import svds
-
-                rows_sp, cols_sp, data_sp = [], [], []
-                if comp_id in comp_to_edges:
-                    for u, v, d in comp_to_edges[comp_id]:
-                        ui = global_to_sub_id[u]
-                        vi = global_to_sub_id[v]
-                        sim = 1.0 - d
-                        rows_sp.extend([ui, vi])
-                        cols_sp.extend([vi, ui])
-                        data_sp.extend([sim, sim])
-
-                comp_matrix = sp.csr_matrix(
-                    (data_sp, (rows_sp, cols_sp)), shape=(size, size), dtype=np.float32
-                )
-                comp_matrix.setdiag(1.0)
-
-                k = min(50, size - 1)
-                u, s, vt = svds(comp_matrix, k=k)
-                embeddings = u @ np.diag(np.sqrt(s))
-                del comp_matrix, rows_sp, cols_sp, data_sp
-
-                clusterer = hdbscan.HDBSCAN(
-                    min_cluster_size=min(min_cluster_size, size),
-                    min_samples=min(min_samples, size),
-                    cluster_selection_epsilon=cluster_selection_epsilon,
-                    cluster_selection_method=selection_method,
-                    metric="euclidean",
-                    gen_min_span_tree=True,
-                )
-                clusterer.fit(embeddings)
-            else:
-                sub_dist = np.ones((size, size), dtype=np.float32)
-                np.fill_diagonal(sub_dist, 0)
-
-                if comp_id in comp_to_edges:
-                    for u, v, d in comp_to_edges[comp_id]:
-                        ui = global_to_sub_id[u]
-                        vi = global_to_sub_id[v]
-                        sub_dist[ui, vi] = d
-                        sub_dist[vi, ui] = d
-
-                clusterer = hdbscan.HDBSCAN(
-                    min_cluster_size=min(min_cluster_size, size),
-                    min_samples=min(min_samples, size),
-                    cluster_selection_epsilon=cluster_selection_epsilon,
-                    cluster_selection_method=selection_method,
-                    metric="precomputed",
-                    gen_min_span_tree=True,
-                )
-                clusterer.fit(sub_dist.astype(np.float64))
-
-            local_tree_df = clusterer.condensed_tree_.to_pandas()
-            if local_tree_df.empty:
-                for node in comp_nodes:
-                    comp_roots.append((node, 1))
-                continue
-
-            sub_internal_to_global = {}
-            # Ensure local root maps to a single global internal ID
-            local_root_sub = local_tree_df["parent"].min()
-
-            for _, row in local_tree_df.iterrows():
-                parent = int(row["parent"])
-                child = int(row["child"])
-
-                if parent not in sub_internal_to_global:
-                    sub_internal_to_global[parent] = next_cluster_id
-                    next_cluster_id += 1
-
-                if child < size:  # Leaf
-                    global_child = sub_id_to_global[child]
-                else:  # Internal
-                    if child not in sub_internal_to_global:
-                        sub_internal_to_global[child] = next_cluster_id
-                        next_cluster_id += 1
-                    global_child = sub_internal_to_global[child]
-
-                global_tree_rows.append(
-                    {
-                        "parent": sub_internal_to_global[parent],
-                        "child": global_child,
-                        "lambda_val": float(row["lambda_val"]),
-                        "child_size": int(row["child_size"]),
-                    }
-                )
-
-            comp_roots.append((sub_internal_to_global[local_root_sub], size))
-
-        fit_time = time.time() - start_fit
-
-        msg = f"HDBSCAN fit completed in {fit_time:.2f}s."
-        logging.info(f"[+] {msg}")
-        if job_service and job_id:
-            job_service.add_log(job_id, msg)
-
-        # Stitch all roots to a synthetic global root at lambda 1.0 (distance 1.0)
-        for comp_root, size in comp_roots:
-            global_tree_rows.append(
-                {
-                    "parent": global_root_id,
-                    "child": comp_root,
-                    "lambda_val": 1.0,
-                    "child_size": size,
-                }
+            tree_df, global_root_id = build_leiden_tree(
+                edges,
+                num_nodes,
+                resolution=resolution,
+                stop_cohesion=stop_cohesion,
+                min_size=min_cluster_size,
+                job_service=job_service,
+                job_id=job_id,
+            )
+        else:
+            tree_df, global_root_id = self._hdbscan_tree(
+                edges,
+                num_nodes,
+                min_cluster_size,
+                min_samples,
+                cluster_selection_epsilon,
+                selection_method,
+                job_service,
+                job_id,
             )
 
-        tree_df = pd.DataFrame(global_tree_rows)
+        if tree_df.empty:
+            logging.warning(f"No clusters produced for {collection}:{algo}.")
+            if job_service and job_id:
+                job_service.add_log(job_id, "No clusters produced.")
+            return True
 
-        msg = f"Global condensed tree has {len(tree_df)} rows."
-        logging.info(f"[*] {msg}")
-        if job_service and job_id:
-            job_service.add_log(job_id, msg)
-
-        # 1. Birth lambdas for all clusters
-        # Root birth is 0
+        # Birth/death lambdas from the FINAL tree (both algos), used below for
+        # per-function membership scores.
         root_id = tree_df["parent"].min()
         birth_lambdas = {root_id: 0.0}
         for _, row in tree_df.iterrows():
             if row["child_size"] > 1:
                 birth_lambdas[int(row["child"])] = float(row["lambda_val"])
-
-        # 2. Death lambdas for all clusters (max lambda of any child)
         death_lambdas = {}
         for _, row in tree_df.iterrows():
             p = int(row["parent"])
             l = float(row["lambda_val"])
             if p not in death_lambdas or l > death_lambdas[p]:
                 death_lambdas[p] = l
-
-        # Stability and per-point strengths will be calculated after extracting members
-        pass
-
-        # Pruning tree based on cluster_selection_epsilon (if > 0)
-        pruned_clusters = set()
-        if cluster_selection_epsilon and cluster_selection_epsilon > 0.0:
-            lambda_threshold = 1.0 / cluster_selection_epsilon
-            for c, b_lambda in birth_lambdas.items():
-                if b_lambda > lambda_threshold:
-                    pruned_clusters.add(c)
-
-        child_to_parent = dict(zip(tree_df["child"], tree_df["parent"]))
-
-        def get_nearest_non_pruned_ancestor(node):
-            curr = node
-            while curr in child_to_parent:
-                p = child_to_parent[curr]
-                if p not in pruned_clusters:
-                    return p
-                curr = p
-            return None
-
-        # Build a pruned tree DataFrame
-        if pruned_clusters:
-            pruned_rows = []
-            for _, row in tree_df.iterrows():
-                parent = int(row["parent"])
-                child = int(row["child"])
-                child_size = int(row["child_size"])
-                lambda_val = float(row["lambda_val"])
-
-                if parent in pruned_clusters:
-                    ancestor = get_nearest_non_pruned_ancestor(parent)
-                    if ancestor is not None:
-                        parent = ancestor
-                    else:
-                        continue  # Skip if no ancestor
-
-                if child_size > 1:
-                    if child in pruned_clusters:
-                        continue
-
-                pruned_rows.append(
-                    {
-                        "parent": parent,
-                        "child": child,
-                        "lambda_val": lambda_val,
-                        "child_size": child_size,
-                    }
-                )
-            import pandas as pd
-
-            tree_df = pd.DataFrame(pruned_rows)
 
         # 4. Extract Condensed Tree for UI and Hierarchical Storage
         tree_json = tree_df.to_json(orient="records")
@@ -814,6 +628,266 @@ class ClusterService:
 
         return True
 
+    def _hdbscan_tree(
+        self,
+        edges,
+        num_nodes,
+        min_cluster_size,
+        min_samples,
+        cluster_selection_epsilon,
+        selection_method,
+        job_service=None,
+        job_id=None,
+    ):
+        """Build the condensed-tree (tree_df, global_root_id) via per-component HDBSCAN."""
+        # 3. Connected Components and Local HDBSCAN
+        import scipy.sparse as sp
+        from scipy.sparse.csgraph import connected_components
+        import pandas as pd
+
+        msg = f"Shattering graph into connected components to avoid OOM..."
+        logging.info(f"[*] {msg}")
+        if job_service and job_id:
+            job_service.add_log(job_id, msg)
+
+        rows = []
+        cols = []
+        data = []
+        for i, j, d in edges:
+            if d < 1.0:  # Only real similarity edges
+                rows.extend([i, j])
+                cols.extend([j, i])
+                data.extend([1, 1])
+
+        adj_matrix = sp.csr_matrix((data, (rows, cols)), shape=(num_nodes, num_nodes))
+        n_components, labels = connected_components(csgraph=adj_matrix, directed=False)
+
+        comp_to_nodes = {}
+        for i, comp_id in enumerate(labels):
+            if comp_id not in comp_to_nodes:
+                comp_to_nodes[comp_id] = []
+            comp_to_nodes[comp_id].append(i)
+
+        comp_to_edges = {}
+        for i, j, d in edges:
+            c = labels[i]
+            if c == labels[j]:
+                if c not in comp_to_edges:
+                    comp_to_edges[c] = []
+                comp_to_edges[c].append((i, j, d))
+
+        msg = f"Found {n_components} connected components. Running local HDBSCAN..."
+        logging.info(f"[*] {msg}")
+        if job_service and job_id:
+            job_service.add_log(job_id, msg)
+
+        global_tree_rows = []
+        global_root_id = num_nodes
+        next_cluster_id = num_nodes + 1
+        comp_roots = []
+
+        start_fit = time.time()
+
+        for comp_id, comp_nodes in comp_to_nodes.items():
+            size = len(comp_nodes)
+            if size < min_cluster_size:
+                for node in comp_nodes:
+                    comp_roots.append((node, 1))
+                continue
+
+            sub_id_to_global = {
+                i: global_idx for i, global_idx in enumerate(comp_nodes)
+            }
+            global_to_sub_id = {
+                global_idx: i for i, global_idx in enumerate(comp_nodes)
+            }
+
+            if size >= 5000:
+                from scipy.sparse.linalg import svds
+
+                rows_sp, cols_sp, data_sp = [], [], []
+                if comp_id in comp_to_edges:
+                    for u, v, d in comp_to_edges[comp_id]:
+                        ui = global_to_sub_id[u]
+                        vi = global_to_sub_id[v]
+                        sim = 1.0 - d
+                        rows_sp.extend([ui, vi])
+                        cols_sp.extend([vi, ui])
+                        data_sp.extend([sim, sim])
+
+                comp_matrix = sp.csr_matrix(
+                    (data_sp, (rows_sp, cols_sp)), shape=(size, size), dtype=np.float32
+                )
+                comp_matrix.setdiag(1.0)
+
+                k = min(50, size - 1)
+                u, s, vt = svds(comp_matrix, k=k)
+                embeddings = u @ np.diag(np.sqrt(s))
+                del comp_matrix, rows_sp, cols_sp, data_sp
+
+                clusterer = hdbscan.HDBSCAN(
+                    min_cluster_size=min(min_cluster_size, size),
+                    min_samples=min(min_samples, size),
+                    cluster_selection_epsilon=cluster_selection_epsilon,
+                    cluster_selection_method=selection_method,
+                    metric="euclidean",
+                    gen_min_span_tree=True,
+                )
+                clusterer.fit(embeddings)
+            else:
+                sub_dist = np.ones((size, size), dtype=np.float32)
+                np.fill_diagonal(sub_dist, 0)
+
+                if comp_id in comp_to_edges:
+                    for u, v, d in comp_to_edges[comp_id]:
+                        ui = global_to_sub_id[u]
+                        vi = global_to_sub_id[v]
+                        sub_dist[ui, vi] = d
+                        sub_dist[vi, ui] = d
+
+                clusterer = hdbscan.HDBSCAN(
+                    min_cluster_size=min(min_cluster_size, size),
+                    min_samples=min(min_samples, size),
+                    cluster_selection_epsilon=cluster_selection_epsilon,
+                    cluster_selection_method=selection_method,
+                    metric="precomputed",
+                    gen_min_span_tree=True,
+                )
+                clusterer.fit(sub_dist.astype(np.float64))
+
+            local_tree_df = clusterer.condensed_tree_.to_pandas()
+            if local_tree_df.empty:
+                for node in comp_nodes:
+                    comp_roots.append((node, 1))
+                continue
+
+            sub_internal_to_global = {}
+            # Ensure local root maps to a single global internal ID
+            local_root_sub = local_tree_df["parent"].min()
+
+            for _, row in local_tree_df.iterrows():
+                parent = int(row["parent"])
+                child = int(row["child"])
+
+                if parent not in sub_internal_to_global:
+                    sub_internal_to_global[parent] = next_cluster_id
+                    next_cluster_id += 1
+
+                if child < size:  # Leaf
+                    global_child = sub_id_to_global[child]
+                else:  # Internal
+                    if child not in sub_internal_to_global:
+                        sub_internal_to_global[child] = next_cluster_id
+                        next_cluster_id += 1
+                    global_child = sub_internal_to_global[child]
+
+                global_tree_rows.append(
+                    {
+                        "parent": sub_internal_to_global[parent],
+                        "child": global_child,
+                        "lambda_val": float(row["lambda_val"]),
+                        "child_size": int(row["child_size"]),
+                    }
+                )
+
+            comp_roots.append((sub_internal_to_global[local_root_sub], size))
+
+        fit_time = time.time() - start_fit
+
+        msg = f"HDBSCAN fit completed in {fit_time:.2f}s."
+        logging.info(f"[+] {msg}")
+        if job_service and job_id:
+            job_service.add_log(job_id, msg)
+
+        # Stitch all roots to a synthetic global root at lambda 1.0 (distance 1.0)
+        for comp_root, size in comp_roots:
+            global_tree_rows.append(
+                {
+                    "parent": global_root_id,
+                    "child": comp_root,
+                    "lambda_val": 1.0,
+                    "child_size": size,
+                }
+            )
+
+        tree_df = pd.DataFrame(global_tree_rows)
+
+        msg = f"Global condensed tree has {len(tree_df)} rows."
+        logging.info(f"[*] {msg}")
+        if job_service and job_id:
+            job_service.add_log(job_id, msg)
+
+        # 1. Birth lambdas for all clusters
+        # Root birth is 0
+        root_id = tree_df["parent"].min()
+        birth_lambdas = {root_id: 0.0}
+        for _, row in tree_df.iterrows():
+            if row["child_size"] > 1:
+                birth_lambdas[int(row["child"])] = float(row["lambda_val"])
+
+        # 2. Death lambdas for all clusters (max lambda of any child)
+        death_lambdas = {}
+        for _, row in tree_df.iterrows():
+            p = int(row["parent"])
+            l = float(row["lambda_val"])
+            if p not in death_lambdas or l > death_lambdas[p]:
+                death_lambdas[p] = l
+
+        # Stability and per-point strengths will be calculated after extracting members
+        pass
+
+        # Pruning tree based on cluster_selection_epsilon (if > 0)
+        pruned_clusters = set()
+        if cluster_selection_epsilon and cluster_selection_epsilon > 0.0:
+            lambda_threshold = 1.0 / cluster_selection_epsilon
+            for c, b_lambda in birth_lambdas.items():
+                if b_lambda > lambda_threshold:
+                    pruned_clusters.add(c)
+
+        child_to_parent = dict(zip(tree_df["child"], tree_df["parent"]))
+
+        def get_nearest_non_pruned_ancestor(node):
+            curr = node
+            while curr in child_to_parent:
+                p = child_to_parent[curr]
+                if p not in pruned_clusters:
+                    return p
+                curr = p
+            return None
+
+        # Build a pruned tree DataFrame
+        if pruned_clusters:
+            pruned_rows = []
+            for _, row in tree_df.iterrows():
+                parent = int(row["parent"])
+                child = int(row["child"])
+                child_size = int(row["child_size"])
+                lambda_val = float(row["lambda_val"])
+
+                if parent in pruned_clusters:
+                    ancestor = get_nearest_non_pruned_ancestor(parent)
+                    if ancestor is not None:
+                        parent = ancestor
+                    else:
+                        continue  # Skip if no ancestor
+
+                if child_size > 1:
+                    if child in pruned_clusters:
+                        continue
+
+                pruned_rows.append(
+                    {
+                        "parent": parent,
+                        "child": child,
+                        "lambda_val": lambda_val,
+                        "child_size": child_size,
+                    }
+                )
+            import pandas as pd
+
+            tree_df = pd.DataFrame(pruned_rows)
+        return tree_df, global_root_id
+
     def clear_clustering(
         self, collection, algo="unweighted_cosine", job_service=None, job_id=None
     ):
@@ -938,9 +1012,7 @@ class ClusterService:
         # not algo-relative clean ids. Non-pool keys carry :{algo}: and strip to clean ids.
         is_pool = collection.startswith("global:pool:")
         sim_score_key = (
-            f"{collection}:sim:score"
-            if is_pool
-            else f"{collection}:sim:score:{algo}"
+            f"{collection}:sim:score" if is_pool else f"{collection}:sim:score:{algo}"
         )
 
         from bsimvis.app.services.index_service import (

--- a/bsimvis/app/services/cluster_service.py
+++ b/bsimvis/app/services/cluster_service.py
@@ -1359,9 +1359,14 @@ class ClusterService:
         min_features=None,
         job_service=None,
         job_id=None,
+        algorithm=None,
+        resolution=None,
+        stop_cohesion=None,
     ):
         """
-        Runs HDBSCAN clustering on pool-namespaced similarity pairs by delegating to run_clustering.
+        Runs clustering on pool-namespaced similarity pairs by delegating to
+        run_clustering. Algorithm ("hdbscan" | "leiden") and its knobs come from
+        the pool's func_cluster_params unless overridden.
         """
         from bsimvis.app.services.pool_service import pool_service
         from bsimvis.app.services.config_service import config_service
@@ -1425,6 +1430,24 @@ class ClusterService:
                 min_features = config_service.get("clustering.min_features", 0)
             min_features = int(min_features)
 
+        # Clustering algorithm + Leiden knobs (func_cluster_params.cluster_algo)
+        if algorithm is None:
+            algorithm = func_cluster_params.get("cluster_algo") or cluster_params.get(
+                "cluster_algo"
+            )
+            if algorithm is None:
+                algorithm = config_service.get("clustering.algorithm", "hdbscan")
+        if resolution is None:
+            resolution = func_cluster_params.get("resolution")
+            if resolution is None:
+                resolution = config_service.get("clustering.resolution", 1.0)
+            resolution = float(resolution)
+        if stop_cohesion is None:
+            stop_cohesion = func_cluster_params.get("stop_cohesion")
+            if stop_cohesion is None:
+                stop_cohesion = config_service.get("clustering.stop_cohesion", 0.9)
+            stop_cohesion = float(stop_cohesion)
+
         algo = pool.get("algo", "unweighted_cosine")
         pool_coll = f"global:pool:{pool_id}"
 
@@ -1438,6 +1461,9 @@ class ClusterService:
             selection_method=selection_method,
             min_sim=min_sim,
             min_features=min_features,
+            algorithm=algorithm,
+            resolution=resolution,
+            stop_cohesion=stop_cohesion,
             job_service=job_service,
             job_id=job_id,
         )

--- a/bsimvis/app/services/cluster_service.py
+++ b/bsimvis/app/services/cluster_service.py
@@ -477,18 +477,13 @@ class ClusterService:
         if job_service and job_id:
             job_service.add_log(job_id, "Extracting hierarchical clusters from tree...")
 
-        # Build tree traversal mapping
-        child_to_parent = dict(zip(tree_df["child"], tree_df["parent"]))
+        # Map leaves to the clusters they actually survive into (shed noise
+        # points excluded). See cluster_common.hierarchical_membership.
+        from bsimvis.app.services.cluster_common import hierarchical_membership
 
-        leaf_to_clusters = {}
-        for leaf in range(num_nodes):
-            clusters = set()
-            curr = leaf
-            while curr in child_to_parent:
-                p = child_to_parent[curr]
-                clusters.add(int(p))
-                curr = p
-            leaf_to_clusters[leaf] = list(clusters)
+        leaf_to_clusters, leaf_home = hierarchical_membership(
+            tree_df, num_nodes, global_root_id, min_size=min_cluster_size
+        )
 
         # Reverse map to find cluster members
         cluster_members = {}
@@ -539,17 +534,12 @@ class ClusterService:
                 pipe.execute()
         pipe.execute()
 
-        # Extract and save direct members (where child_size == 1)
+        # Direct members = leaves whose deepest surviving cluster is this node
+        # (shed noise points are excluded, matching the membership rule above).
         direct_members = {}
-        for _, row in tree_df.iterrows():
-            if int(row["child_size"]) == 1:
-                p = int(row["parent"])
-                leaf = int(row["child"])
-                if leaf in idx_to_id:
-                    fid = idx_to_id[leaf]
-                    if p not in direct_members:
-                        direct_members[p] = []
-                    direct_members[p].append(fid)
+        for leaf, p in leaf_home.items():
+            if leaf in idx_to_id:
+                direct_members.setdefault(p, []).append(idx_to_id[leaf])
 
         for c, d_members in direct_members.items():
             pipe.sadd(f"{collection}:cluster:{algo}:{c}:direct_members", *d_members)

--- a/bsimvis/app/services/cluster_service.py
+++ b/bsimvis/app/services/cluster_service.py
@@ -1654,17 +1654,13 @@ class ClusterService:
             f"global:pool:{pool_id}:bin_cluster:tree_links:{algo}",
             json.dumps(tree_links),
         )
-        # Extract cluster members from tree
-        child_to_parent = dict(zip(tree_df["child"], tree_df["parent"]))
-        leaf_to_clusters = {}
-        for leaf in range(num_nodes):
-            clusters = set()
-            curr = leaf
-            while curr in child_to_parent:
-                p = child_to_parent[curr]
-                clusters.add(int(p))
-                curr = p
-            leaf_to_clusters[leaf] = list(clusters)
+        # Extract cluster members (shed noise excluded, synthetic root and
+        # sub-min_cluster_size survivors dropped). See cluster_common.
+        from bsimvis.app.services.cluster_common import hierarchical_membership
+
+        leaf_to_clusters, _ = hierarchical_membership(
+            tree_df, num_nodes, global_root_id, min_size=min_cluster_size
+        )
 
         cluster_members = {}
         for leaf, clusters in leaf_to_clusters.items():
@@ -1676,11 +1672,6 @@ class ClusterService:
                     cluster_members[c].append(fid)
 
         root_id = tree_df["parent"].min()
-        cluster_members = {
-            c: m
-            for c, m in cluster_members.items()
-            if c != root_id and len(m) >= min_cluster_size
-        }
 
         # Stability
         birth_lambdas = {root_id: 0.0}

--- a/bsimvis/app/static/js/dashboard.js
+++ b/bsimvis/app/static/js/dashboard.js
@@ -4281,8 +4281,10 @@ async function renderPoolCreationForm() {
     const funcClusterMinSamples = clustering.min_samples !== undefined ? clustering.min_samples : 1;
     const funcClusterEpsilon = clustering.epsilon !== undefined ? clustering.epsilon : 0.1;
     const funcClusterMethod = clustering.selection_method || 'eom';
+    const funcClusterAlgo = clustering.algorithm || 'hdbscan';
+    const funcClusterResolution = clustering.resolution !== undefined ? clustering.resolution : 1.0;
+    const funcClusterStopCohesion = clustering.stop_cohesion !== undefined ? clustering.stop_cohesion : 0.9;
 
-    const fileAlgo = similarity.algo || 'unweighted_cosine';
     const fileTopK = 100; // default for file-level similarity
     const fileMinScore = 0.5; // default for file-level similarity
     const fileClusterMinSize = clustering.min_cluster_size !== undefined ? clustering.min_cluster_size : 2;
@@ -4384,6 +4386,23 @@ async function renderPoolCreationForm() {
                                             </div>
                                         </div>
                                     </div>
+                                    <div style="margin-bottom:10px;">
+                                        <label style="display:block; font-size:0.65rem; color:var(--dim); margin-bottom:4px;">Algorithm</label>
+                                        <select id="pool-cluster-algo" onchange="togglePoolLeidenParams()" style="width:100%; background:rgba(0,0,0,0.2); border:1px solid var(--border); color:var(--text); padding:6px; border-radius:4px; font-size:0.75rem;">
+                                            <option value="hdbscan" ${funcClusterAlgo === 'hdbscan' ? 'selected' : ''}>HDBSCAN (hierarchical density)</option>
+                                            <option value="leiden" ${funcClusterAlgo === 'leiden' ? 'selected' : ''}>Leiden (recursive community)</option>
+                                        </select>
+                                    </div>
+                                    <div id="pool-leiden-params" style="display:${funcClusterAlgo === 'leiden' ? 'grid' : 'none'}; grid-template-columns:1fr 1fr; gap:10px; margin-bottom:10px;">
+                                        <div>
+                                            <label style="display:block; font-size:0.65rem; color:var(--dim); margin-bottom:4px;" title="Higher = smaller, tighter clusters">Resolution</label>
+                                            <input type="number" id="pool-cluster-resolution" step="0.1" value="${funcClusterResolution}" style="width:100%; box-sizing:border-box; background:rgba(0,0,0,0.2); border:1px solid var(--border); color:var(--text); padding:6px; border-radius:4px; font-size:0.75rem;">
+                                        </div>
+                                        <div>
+                                            <label style="display:block; font-size:0.65rem; color:var(--dim); margin-bottom:4px;" title="Stop splitting once a group is this cohesive">Stop Cohesion</label>
+                                            <input type="number" id="pool-cluster-stopcohesion" step="0.05" value="${funcClusterStopCohesion}" style="width:100%; box-sizing:border-box; background:rgba(0,0,0,0.2); border:1px solid var(--border); color:var(--text); padding:6px; border-radius:4px; font-size:0.75rem;">
+                                        </div>
+                                    </div>
                                     <div style="display:grid; grid-template-columns: 1fr 1fr; gap:10px;">
                                         <div>
                                             <label style="display:block; font-size:0.65rem; color:var(--dim); margin-bottom:4px;">Min Cluster</label>
@@ -4422,13 +4441,9 @@ async function renderPoolCreationForm() {
                                 <div id="file-params-grid" style="display:grid; grid-template-columns: 1fr 1fr; gap:20px; transition: opacity 0.2s;">
                                     <div>
                                         <div style="display:grid; grid-template-columns: 1fr; gap:10px;">
-                                            <div>
-                                                <label style="display:block; font-size:0.65rem; color:var(--dim); margin-bottom:4px;">Algorithm</label>
-                                                <select id="pool-file-algo" style="width:100%; background:rgba(0,0,0,0.2); border:1px solid var(--border); color:var(--text); padding:6px; border-radius:4px; font-size:0.75rem;">
-                                                    <option value="unweighted_cosine" ${fileAlgo === 'unweighted_cosine' ? 'selected' : ''}>Unweighted Cosine</option>
-                                                    <option value="weighted_cosine" ${fileAlgo === 'weighted_cosine' ? 'selected' : ''}>Weighted Cosine</option>
-                                                    <option value="jaccard" ${fileAlgo === 'jaccard' ? 'selected' : ''}>Jaccard</option>
-                                                </select>
+                                            <div style="font-size:0.65rem; color:var(--dim); line-height:1.4;">
+                                                <i class="fa-solid fa-circle-info"></i>
+                                                File similarity is derived from shared function clusters — it inherits the function algorithm above, there is no separate file-level algorithm.
                                             </div>
                                             <div style="display:grid; grid-template-columns: 1fr 1fr; gap:8px;">
                                                 <div>
@@ -4519,6 +4534,14 @@ function togglePoolCreationForm() {
 }
 window.togglePoolCreationForm = togglePoolCreationForm;
 
+function togglePoolLeidenParams() {
+    const sel = document.getElementById('pool-cluster-algo');
+    const params = document.getElementById('pool-leiden-params');
+    if (!sel || !params) return;
+    params.style.display = sel.value === 'leiden' ? 'grid' : 'none';
+}
+window.togglePoolLeidenParams = togglePoolLeidenParams;
+
 function filterPoolCollections(val) {
     const list = document.getElementById('pool-collections-list');
     if (!list) return;
@@ -4545,10 +4568,12 @@ async function submitCreatePool(btn) {
     const funcClusterMinSamples = parseInt(document.getElementById('pool-cluster-min-samples')?.value || '1');
     const funcClusterEpsilon = parseFloat(document.getElementById('pool-cluster-epsilon')?.value || '0.1');
     const funcClusterMethod = document.getElementById('pool-cluster-method')?.value ?? 'eom';
-    
+    const funcClusterAlgo = document.getElementById('pool-cluster-algo')?.value ?? 'hdbscan';
+    const funcClusterResolution = parseFloat(document.getElementById('pool-cluster-resolution')?.value || '1.0');
+    const funcClusterStopCohesion = parseFloat(document.getElementById('pool-cluster-stopcohesion')?.value || '0.9');
+
     // File settings
     const enableFiles = document.getElementById('pool-enable-files')?.checked ?? false;
-    const fileAlgo = document.getElementById('pool-file-algo')?.value ?? 'unweighted_cosine';
     const fileTopK = parseInt(document.getElementById('pool-file-topk')?.value || '100');
     const fileMinScore = parseFloat(document.getElementById('pool-file-minscore')?.value || '0.5');
     const fileClusterMinSize = parseInt(document.getElementById('pool-file-cluster-min-size')?.value || '2');
@@ -4592,14 +4617,16 @@ async function submitCreatePool(btn) {
                         min_features: funcMinFeatures
                     },
                     func_cluster_params: {
+                        cluster_algo: funcClusterAlgo,
+                        resolution: funcClusterResolution,
+                        stop_cohesion: funcClusterStopCohesion,
                         min_cluster_size: funcClusterMinSize,
                         min_samples: funcClusterMinSamples,
                         epsilon: funcClusterEpsilon,
                         selection_method: funcClusterMethod
                     },
-                    file_sim_params: { 
+                    file_sim_params: {
                         enabled: enableFiles,
-                        algo: fileAlgo,
                         top_k: fileTopK,
                         min_score: fileMinScore
                     },

--- a/bsimvis/app/static/js/views/pool_detail_view.js
+++ b/bsimvis/app/static/js/views/pool_detail_view.js
@@ -301,10 +301,13 @@ window.PoolDetailView = {
                         ${this._configRow('Top K', fs.top_k)}
                         ${this._configRow('Min Score', fs.min_score)}
                         ${this._configRow('Min Features', fs.min_features)}
+                        ${this._configRow('Cluster Algorithm', fc.cluster_algo || 'hdbscan')}
+                        ${(fc.cluster_algo === 'leiden') ? this._configRow('Resolution', fc.resolution ?? 1.0) : ''}
+                        ${(fc.cluster_algo === 'leiden') ? this._configRow('Stop Cohesion', fc.stop_cohesion ?? 0.9) : ''}
                         ${this._configRow('Min Cluster Size', fc.min_cluster_size)}
-                        ${this._configRow('Min Samples', fc.min_samples)}
-                        ${this._configRow('Epsilon', fc.epsilon)}
-                        ${this._configRow('Method', fc.selection_method)}
+                        ${(fc.cluster_algo === 'leiden') ? '' : this._configRow('Min Samples', fc.min_samples)}
+                        ${(fc.cluster_algo === 'leiden') ? '' : this._configRow('Epsilon', fc.epsilon)}
+                        ${(fc.cluster_algo === 'leiden') ? '' : this._configRow('Method', fc.selection_method)}
                     </div>
 
                     <!-- File Sim -->
@@ -312,7 +315,6 @@ window.PoolDetailView = {
                         <div style="font-size:0.72rem; font-weight:700; text-transform:uppercase; letter-spacing:0.07em; color:${fileSimEnabled ? '#60a5fa' : 'var(--dim)'}; margin-bottom:12px; display:flex; align-items:center; gap:7px; border-bottom:1px solid rgba(255,255,255,0.05); padding-bottom:10px;">
                             <i class="fa-solid fa-file-code"></i> File Similarity ${fileSimEnabled ? '' : '<span style="font-size:0.65rem; margin-left:4px; color:var(--dim);">(disabled)</span>'}
                         </div>
-                        ${this._configRow('Algorithm', fis.algo)}
                         ${this._configRow('Top K', fis.top_k)}
                         ${this._configRow('Min Score', fis.min_score)}
                         ${this._configRow('Min Cluster Size', fic.min_cluster_size)}

--- a/bsimvis/app/swagger.py
+++ b/bsimvis/app/swagger.py
@@ -1498,6 +1498,17 @@ class ClusterBuild(Resource):
             {
                 "collection": fields.String(default="main"),
                 "algo": fields.String(default="unweighted_cosine"),
+                "algorithm": fields.String(
+                    default="hdbscan",
+                    description="Clustering algorithm: 'hdbscan' or 'leiden'",
+                ),
+                "resolution": fields.Float(
+                    default=1.0, description="Leiden granularity (higher = tighter)"
+                ),
+                "stop_cohesion": fields.Float(
+                    default=0.9,
+                    description="Leiden: stop recursing once a group is this cohesive",
+                ),
                 "min_cluster_size": fields.Integer(default=2),
                 "min_samples": fields.Integer(default=1),
                 "epsilon": fields.Float(default=0.1),
@@ -2171,7 +2182,16 @@ pool_func_sim_params_model = api.model(
 pool_func_cluster_params_model = api.model(
     "PoolFuncClusterParams",
     {
-        "cluster_algo": fields.String(default="hdbscan"),
+        "cluster_algo": fields.String(
+            default="hdbscan", description="Clustering algorithm: 'hdbscan' or 'leiden'"
+        ),
+        "resolution": fields.Float(
+            default=1.0, description="Leiden granularity (higher = tighter)"
+        ),
+        "stop_cohesion": fields.Float(
+            default=0.9,
+            description="Leiden: stop recursing once a group is this cohesive",
+        ),
         "min_cluster_size": fields.Integer(default=2),
         "min_samples": fields.Integer(default=1),
         "epsilon": fields.Float(default=0.1),
@@ -2231,7 +2251,9 @@ class PoolList(Resource):
                 "example": "mirai",
             },
             "name": {"description": "Substring filter on pool name"},
-            "sync_status": {"description": "Exact sync status: current | outdated | created"},
+            "sync_status": {
+                "description": "Exact sync status: current | outdated | created"
+            },
             "sort_by": {
                 "description": "name | id | created_at | last_built_at | sync_status | count fields",
                 "example": "created_at",
@@ -2277,7 +2299,11 @@ class PoolDetail(Resource):
 
         return delete_pool(pool_id)
 
-    @ns_pool.expect(api.model("PoolUpdate", {"name": fields.String(required=True, example="New Name")}))
+    @ns_pool.expect(
+        api.model(
+            "PoolUpdate", {"name": fields.String(required=True, example="New Name")}
+        )
+    )
     def put(self, pool_id):
         """Updates the pool's name."""
         from bsimvis.app.routes.pools import edit_pool

--- a/bsimvis/worker.py
+++ b/bsimvis/worker.py
@@ -690,6 +690,15 @@ class Worker:
             min_features = payload.get(
                 "min_features", config_service.get("clustering.min_features", 0)
             )
+            algorithm = payload.get(
+                "algorithm", config_service.get("clustering.algorithm", "hdbscan")
+            )
+            resolution = payload.get(
+                "resolution", config_service.get("clustering.resolution", 1.0)
+            )
+            stop_cohesion = payload.get(
+                "stop_cohesion", config_service.get("clustering.stop_cohesion", 0.9)
+            )
 
             return cluster_service.run_clustering(
                 collection,
@@ -700,6 +709,9 @@ class Worker:
                 selection_method=selection_method,
                 min_sim=min_sim,
                 min_features=min_features,
+                algorithm=algorithm,
+                resolution=resolution,
+                stop_cohesion=stop_cohesion,
                 job_service=self.job_service,
                 job_id=job_id,
             )

--- a/bsimvis_config.toml.example
+++ b/bsimvis_config.toml.example
@@ -31,6 +31,13 @@
     description = "Decompile only"
     no_analysis = true
 [clustering]
+    # algorithm = "hdbscan" (default) or "leiden".
+    # leiden = recursive community detection on the sparse similarity graph:
+    # keeps low-cohesion parents for the dendrogram while surfacing tight
+    # high-cohesion sub-groups that HDBSCAN's single-linkage buries.
+    algorithm = "hdbscan"
+    resolution = 1.0        # leiden granularity: higher -> smaller, tighter clusters
+    stop_cohesion = 0.9     # leiden: stop recursing once a group is this cohesive
     epsilon = 0.001
     min_cluster_size = 2
     min_samples = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "pymilvus>=2.4.0",
     "hdbscan>=0.8.40",
     "scikit-learn>=1.6.0",
+    "python-igraph>=0.11",
+    "leidenalg>=0.10",
     "ollama>=0.6.2",
     "matplotlib>=3.11.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -95,11 +95,13 @@ dependencies = [
     { name = "flask-cors" },
     { name = "flask-restx" },
     { name = "hdbscan" },
+    { name = "leidenalg" },
     { name = "matplotlib" },
     { name = "ollama" },
     { name = "pyghidra" },
     { name = "pymilvus" },
     { name = "python-dotenv" },
+    { name = "python-igraph" },
     { name = "redis" },
     { name = "requests" },
     { name = "scikit-learn" },
@@ -113,11 +115,13 @@ requires-dist = [
     { name = "flask-cors", specifier = ">=6.0.2" },
     { name = "flask-restx", specifier = ">=1.3.0" },
     { name = "hdbscan", specifier = ">=0.8.40" },
+    { name = "leidenalg", specifier = ">=0.10" },
     { name = "matplotlib", specifier = ">=3.11.0" },
     { name = "ollama", specifier = ">=0.6.2" },
     { name = "pyghidra", specifier = ">=3.0.2" },
     { name = "pymilvus", specifier = ">=2.4.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-igraph", specifier = ">=0.11" },
     { name = "redis", specifier = ">=7.3.0" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "scikit-learn", specifier = ">=1.6.0" },
@@ -459,6 +463,26 @@ wheels = [
 ]
 
 [[package]]
+name = "igraph"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "texttable" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/be/56bef1919005b4caf1f71522b300d359f7faeb7ae93a3b0baa9b4f146a87/igraph-1.0.0.tar.gz", hash = "sha256:2414d0be2e4d77ee5357807d100974b40f6082bb1bb71988ec46cfb6728651ee", size = 5077105, upload-time = "2025-10-23T12:22:50.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/03/3278ad0ceb3ea0e84d8ae3a85bdded4d0e57853aeb802a200feb43847b93/igraph-1.0.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:c2cbc415e02523e5a241eecee82319080bf928a70b1ba299f3b3e25bf029b6d4", size = 2257415, upload-time = "2025-10-23T12:22:27.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bc/6281ec7f9baaf71ee57c3b1748da2d3148d15d253e1a03006f204aa68ca5/igraph-1.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a27753cd80680a8f676c2d5a467aaa4a95e510b30748398ec4e4aeb982130e8", size = 2048555, upload-time = "2025-10-23T12:22:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/38/3cd6428a4ed4c09a56df05998438e7774fd1d799ee4fb8fc481674f5f7fc/igraph-1.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a55dc3a2a4e3fc3eba42479910c1511bfc3ecb33cdf5f0406891fd85f14b5aee", size = 5314141, upload-time = "2025-10-23T12:22:31.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/da/dd2867c25adbb41563720f14b5fc895c98bf88be682a3faff4f7b3118d2a/igraph-1.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2d04c2c76f686fb1f554ee35dfd3085f5e73b7965ba6b4cf06d53e66b1955522", size = 5683134, upload-time = "2025-10-23T12:22:32.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/40/243c118d34ab80382d7009c4dcb99b887384c3d2ce84d29eeac19e2a007a/igraph-1.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2b52dc1757fff0fed29a9f7a276d971a11db4211569ed78b9eab36288dfcc9d", size = 6211583, upload-time = "2025-10-23T12:22:34.238Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b7/88f433819c54b496cb0315fce28e658970cb20ff5dbd52a5a605ce2888de/igraph-1.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:05c79a2a8fca695b2f217a6fa7f2549f896f757d4db41be32a055400cb19cc30", size = 6594509, upload-time = "2025-10-23T12:22:35.831Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5d/8f7f6f619d374e959aa3664ebc4b24c10abc90c2e8efbed97f2623fadaf5/igraph-1.0.0-cp39-abi3-win32.whl", hash = "sha256:c2bce3cd472fec3dd9c4d8a3ea5b6b9be65fb30edf760beb4850760dd4f2d479", size = 2725406, upload-time = "2025-10-23T12:22:37.588Z" },
+    { url = "https://files.pythonhosted.org/packages/af/77/a85b3745cf40a0572bae2de8cd9c2a2a8af78e5cf3e880fc0a249114e609/igraph-1.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:faeff8ede0cf15eb4ded44b0fcea6e1886740146e60504c24ad2da14e0939563", size = 3221663, upload-time = "2025-10-23T12:22:39.404Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/7e/5df541c37bdf6493035e89c22bd53f30d99b291bcda6c78e9a8afeecec2b/igraph-1.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:b607cafc24b10a615e713ee96e58208ef27e0764af80140c7cc45d4724a3f2df", size = 2785701, upload-time = "2025-10-23T12:22:41.03Z" },
+]
+
+[[package]]
 name = "importlib-resources"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -608,6 +632,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/18/43a5f24608d8c313dd189cf838c8e68d75b115567c6279de7796197cfb6a/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646", size = 2394403, upload-time = "2026-03-09T13:15:31.517Z" },
     { url = "https://files.pythonhosted.org/packages/3b/b5/98222136d839b8afabcaa943b09bd05888c2d36355b7e448550211d1fca4/kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681", size = 79687, upload-time = "2026-03-09T13:15:33.204Z" },
     { url = "https://files.pythonhosted.org/packages/99/a2/ca7dc962848040befed12732dff6acae7fb3c4f6fc4272b3f6c9a30b8713/kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57", size = 70032, upload-time = "2026-03-09T13:15:34.411Z" },
+]
+
+[[package]]
+name = "leidenalg"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "igraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/b7/45bae25ab59321a14902bec2f47e32b92e76f8b4b3887a13ee69a0b32c60/leidenalg-0.12.0.tar.gz", hash = "sha256:c81a45a2fb874fe71e903d43a869d0efeb7f907af70476c03f6945ef0e8f44c5", size = 453641, upload-time = "2026-05-24T10:17:53.556Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7f/0900c05ccbb27744f9dd11321dc2978e9f5ffe678db54f23eb94cf4e5951/leidenalg-0.12.0-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:96eec407f540d9ddb0c103dadc632d5519cfcdb39689fb21ae0ceeaa97bb2ec3", size = 2257399, upload-time = "2026-05-24T10:17:32.257Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f6/d15c889c7c65dbc41c84fe83243c203b083f70cef62ed0acc630098b2012/leidenalg-0.12.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:2e0e1c2321c2e06a7f4f8a73ca15fcd54e0139a62afb448933c42badcfab8adc", size = 1926700, upload-time = "2026-05-24T10:17:33.946Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/36/7480eef0473bd87f69826e0dfb6bb1c1ee0915fa6d31be445d0bfcbd3a1a/leidenalg-0.12.0-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f6a97f698f13a588e1ae7344908cddee9f87d33acc226fc5c5b99752ebd71f8", size = 2546580, upload-time = "2026-05-24T10:17:35.133Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/cf5eb36b4517bb85397760a6033628695e8b0723b45f10f487b07cec84df/leidenalg-0.12.0-cp38-abi3-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:78df2e463f3ffffffda590e9b0d790107e59f722f095731b78a58803d1ca92e5", size = 2845846, upload-time = "2026-05-24T10:17:37.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/be/dba31e662c2ee028e20dd0308c1bc6e398dd7a1786fdd0821722537b4124/leidenalg-0.12.0-cp38-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fcbd89655243cc739d28ba23fe894587d8d7235124a9248ba375819585e70090", size = 2739255, upload-time = "2026-05-24T10:17:38.376Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/02/22597cf6d7ee093523ad5885a31499d698812db5744d98086383c3da08b5/leidenalg-0.12.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:c6a6231d3db490ee3cc4004f214b0bb947dc3fabde75bd61d878bc3fb9685d06", size = 4072277, upload-time = "2026-05-24T10:17:39.881Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/2f3322376fddd6b85790eaddcd314c9402bf81e984b35870acb4cfcbd0e1/leidenalg-0.12.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:63b49f5716c7cb155f3a3e25505bcc33f3c8c62105734fc152bc07518e63e9ab", size = 3799963, upload-time = "2026-05-24T10:17:41.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/35/f4f07ddac6718a11c70d858fd4afcc849ca84f485b5d7092bcf09492ec06/leidenalg-0.12.0-cp38-abi3-win32.whl", hash = "sha256:283cd987623e2c5e7b11ed3f15b7805d597a934bf387a7e820d2f673001b635f", size = 1675833, upload-time = "2026-05-24T10:17:42.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/77/0c8fb67729e83bddd43971cd4851f497a96810fca63f8029e3f008e82b1b/leidenalg-0.12.0-cp38-abi3-win_amd64.whl", hash = "sha256:f5d9529b44d5f6add0847d68fa6ced99f581357f6ca02b54c049eb3a2f45ff04", size = 1990568, upload-time = "2026-05-24T10:17:44.071Z" },
 ]
 
 [[package]]
@@ -1097,6 +1141,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-igraph"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "igraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/b6/3c1476ec6bf06348ecea1d76af6c6b3a024dddbcd2de120d3a0de1eab29b/python_igraph-1.0.0.tar.gz", hash = "sha256:6da7ac4e9f6a9cf03734798bed6fb082bb9274f2ae288f6099121f0332803018", size = 9726, upload-time = "2025-10-23T12:28:36.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/5f/567fa047076d32d321bdafa248905a7186d2acee4916b046b11417af10d9/python_igraph-1.0.0-py3-none-any.whl", hash = "sha256:b0bb8d91cce2a1e0550fe45f9ec925bcd04152dfb5be3fa822b9f5f36eb3f380", size = 9157, upload-time = "2025-10-23T12:28:33.515Z" },
+]
+
+[[package]]
 name = "pytokens"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1328,6 +1384,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "texttable"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/dc/0aff23d6036a4d3bf4f1d8c8204c5c79c4437e25e0ae94ffe4bbb55ee3c2/texttable-1.7.0.tar.gz", hash = "sha256:2d2068fb55115807d3ac77a4ca68fa48803e84ebb0ee2340f858107a36522638", size = 12831, upload-time = "2023-10-03T09:48:12.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/99/4772b8e00a136f3e01236de33b0efda31ee7077203ba5967fcc76da94d65/texttable-1.7.0-py2.py3-none-any.whl", hash = "sha256:72227d592c82b3d7f672731ae73e4d1f88cd8e2ef5b075a7a7f01a23a3743917", size = 10768, upload-time = "2023-10-03T09:48:10.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Rebased onto current `dev` (supersedes #14, which was branched off a stale dev).

## Problem
Two complaints, one root cause:
1. **Cluster metadata wrong** — `member_count`, `cohesion_score` inflated.
2. **Big low-cohesion clusters instead of small precise ones** — e.g. 3 binaries, 2 of them 100% similar, land in one ~80%-cohesion cluster of 3 instead of a precise pair.

## Root cause
HDBSCAN keeps a tight core under one condensed-tree node while loosely-attached members **peel off one-at-a-time as singleton noise** (each < `min_cluster_size`), so no split node is created. The code then built each node's membership by walking **every descendant leaf**, including those shed singletons — diluting the tight core.

Not a parameter problem: `min_samples=1` (needed to keep identical binaries tight) is already the default.

## Fix
A leaf belongs to an ancestor cluster `C` only if it **survives to `C`'s death lambda** (`fallout(leaf) >= death(C)`). Shed points become noise.
- Genuine sub-structure preserved: parent + tight child clusters still all emitted.
- **Dendrogram unchanged** — tree/tree_links storage untouched; only membership/metadata changed.
- Excludes the synthetic global root (was a giant ~0-cohesion cluster) and drops <`min_cluster_size` survivors.
- `direct_members` derived from each leaf's deepest surviving cluster.

Shared logic in `cluster_common.hierarchical_membership`, applied to **all** hierarchical callers: `run_clustering` (function + binary) and `run_pool_bin_clustering`. Redis-free self-check: `uv run python bsimvis/app/services/cluster_common.py`.

## Testing
- Membership logic verified against **real HDBSCAN condensed trees** (self-check asserts tight-pair-vs-loose and two-family cases).
- NOT run end-to-end against live kvrocks (no access to real sim data) — recommend a re-cluster on a throwaway collection before undrafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)