### PR TITLE
perf(features): batch Kvrocks reads in INDEX_FEATURES

### DIFF
--- a/bsimvis/app/services/feature_service.py
+++ b/bsimvis/app/services/feature_service.py
@@ -9,6 +9,26 @@ class FeatureService:
     def __init__(self, r=None):
         self.r = r or get_redis()
 
+    READ_BATCH = 100
+
+    def _fetch_vec_batch(self, func_ids):
+        """GET :vec:meta + ZRANGE :vec:tf for a batch of functions in one round-trip."""
+        pipe = self.r.pipeline(transaction=False)
+        for fid in func_ids:
+            pipe.get(f"{fid}:vec:meta")
+            pipe.zrange(f"{fid}:vec:tf", 0, -1, withscores=True)
+        res = pipe.execute()
+
+        out = {}
+        for idx, fid in enumerate(func_ids):
+            raw_meta = res[idx * 2]
+            if raw_meta:
+                raw_meta = json.loads(raw_meta)
+                if isinstance(raw_meta, list) and len(raw_meta) == 1:
+                    raw_meta = raw_meta[0]
+            out[fid] = (raw_meta, res[idx * 2 + 1])
+        return out
+
     def index_functions(self, collection, function_ids, job_service=None, job_id=None):
         """
         Reverse feature indexing for a list of functions.
@@ -22,27 +42,29 @@ class FeatureService:
         indexed_features = set()
 
         pipe = self.r.pipeline(transaction=False)
+        batch = {}  # func_id -> (raw_meta, tf_data), refilled every READ_BATCH funcs
+        last_pct = -1
 
         for i, func_id in enumerate(function_ids):
-            # Update job progress if applicable
-            if job_service and job_id and (i % 10 == 0 or i == total - 1):
+            # Update job progress if applicable. update_progress is expensive (it
+            # re-aggregates the parent pipeline with one HGET per sibling task), so
+            # only fire it when the whole percent actually moves.
+            if job_service and job_id:
                 pct = int((i + 1) / total * 100)
-                job_service.update_progress(
-                    job_id, pct, f"Indexing features: {i+1}/{total}"
+                if pct != last_pct or i == total - 1:
+                    last_pct = pct
+                    job_service.update_progress(
+                        job_id, pct, f"Indexing features: {i+1}/{total}"
+                    )
+
+            # 1. Fetch metadata and vector data, one round-trip per READ_BATCH
+            # functions instead of two per function.
+            if func_id not in batch:
+                batch = self._fetch_vec_batch(
+                    function_ids[i : i + self.READ_BATCH]
                 )
 
-            meta_key = f"{func_id}:vec:meta"
-            tf_key = f"{func_id}:vec:tf"
-
-            # 1. Fetch metadata and vector data
-            # NOTE: Getting data can't be pipelined easily since it is needed inside loop
-            raw_meta = self.r.get(meta_key)
-            if raw_meta:
-                raw_meta = json.loads(raw_meta)
-                if isinstance(raw_meta, list) and len(raw_meta) == 1:
-                    raw_meta = raw_meta[0]
-
-            new_tf_data = self.r.zrange(tf_key, 0, -1, withscores=True)
+            raw_meta, new_tf_data = batch.pop(func_id)
             if not raw_meta or not new_tf_data:
                 logging.warning(
                     f"  [!] Skipping {func_id}: Missing metadata or vector data."
@@ -395,6 +417,18 @@ class FeatureService:
             results = []
             pending_funcs = {}  # func_id → {func_id, line_idxs list}
 
+            # Features with < 100 occurrences need a full HGETALL (HRANDFIELD may
+            # dedup). That is the common case, so batch them into one round-trip.
+            small_pipe = self.r.pipeline(transaction=False)
+            small_hashes = [
+                fh
+                for idx, fh in enumerate(chunk)
+                if 0 < res1[idx * 3 + 1] <= 100
+            ]
+            for fh in small_hashes:
+                small_pipe.hgetall(f"{collection}:feature:{fh}:meta")
+            small_full = dict(zip(small_hashes, small_pipe.execute()))
+
             for idx, fh in enumerate(chunk):
                 hr = res1[idx * 3]
                 # HRANDFIELD withvalues returns flat list [key1, val1, key2, val2, ...]
@@ -402,9 +436,8 @@ class FeatureService:
                 total_freq = res1[idx * 3 + 1]
                 tf_score_val = res1[idx * 3 + 2]
 
-                # If full hash < 100 entries, re-fetch all (HRANDFIELD may dedup)
-                if total_freq <= 100 and total_freq > 0:
-                    data_batch = self.r.hgetall(f"{collection}:feature:{fh}:meta")
+                if fh in small_full:
+                    data_batch = small_full[fh]
 
                 # parse each occ, include function_id from the hash field
                 parsed = {}

--- a/bsimvis/app/services/feature_service.py
+++ b/bsimvis/app/services/feature_service.py
@@ -1,8 +1,33 @@
 import math
+from collections import defaultdict
 import logging
 import json
 from bsimvis.app.services.redis_client import get_redis
 from bsimvis.app.services.milvus_service import milvus_service
+
+
+class _WriteBuffer:
+    """Merges one window of index_functions writes, keyed by feature hash."""
+
+    def __init__(self):
+        self.norms = {}  # norm key -> value
+        self.zadds = defaultdict(dict)  # f_hash -> {func_id: tf}
+        self.incrs = defaultdict(float)  # f_hash -> summed tf
+        self.metas = defaultdict(dict)  # f_hash -> {func_id: json}
+        self.indexed = []  # func_ids
+
+    def flush(self, pipe, collection):
+        if self.norms:
+            pipe.mset(self.norms)
+        for f_hash, members in self.zadds.items():
+            pipe.zadd(f"{collection}:feature:{f_hash}:functions", members)
+        for f_hash, amount in self.incrs.items():
+            pipe.zincrby(f"{collection}:features:by_tf", amount, f_hash)
+        for f_hash, fields in self.metas.items():
+            pipe.hset(f"{collection}:feature:{f_hash}:meta", mapping=fields)
+        if self.indexed:
+            pipe.sadd(f"{collection}:indexed:functions", *self.indexed)
+        self.__init__()
 
 
 class FeatureService:
@@ -44,6 +69,11 @@ class FeatureService:
         pipe = self.r.pipeline(transaction=False)
         batch = {}  # func_id -> (raw_meta, tf_data), refilled every READ_BATCH funcs
         last_pct = -1
+        # The write fan-out (one ZADD/ZINCRBY/HSET per function *per feature*) is
+        # what actually dominates this job. Features repeat heavily across the
+        # functions of one file, so merge a window's writes per feature hash:
+        # ~40 commands per function collapse to ~1 per distinct feature.
+        acc = _WriteBuffer()
 
         for i, func_id in enumerate(function_ids):
             # Update job progress if applicable. update_progress is expensive (it
@@ -73,7 +103,7 @@ class FeatureService:
 
             # A. Recalculate L2 Norm
             sum_sq = sum(float(tf) ** 2 for _, tf in new_tf_data)
-            pipe.set(f"{func_id}:vec:norm", math.sqrt(sum_sq))
+            acc.norms[f"{func_id}:vec:norm"] = math.sqrt(sum_sq)
 
             # B. Build Reverse Index (ZSETs)
             tf_dict = {
@@ -84,9 +114,9 @@ class FeatureService:
             for f_hash, new_tf in tf_dict.items():
                 indexed_features.add(f_hash)
                 # Update function mapping for this feature
-                pipe.zadd(f"{collection}:feature:{f_hash}:functions", {func_id: new_tf})
+                acc.zadds[f_hash][func_id] = new_tf
                 # Update global TF counter for this feature
-                pipe.zincrby(f"{collection}:features:by_tf", float(new_tf), f_hash)
+                acc.incrs[f_hash] += float(new_tf)
 
             # Store feature metadata as a JSON string in a HASH keyed by function_id
             for feat_item in raw_meta:
@@ -96,17 +126,14 @@ class FeatureService:
                 meta_entry = dict(feat_item)
                 meta_entry["function_id"] = func_id
                 # Convention: {coll}:feature:{hash}:meta -> HASH (field=func_id, value=JSON)
-                pipe.hset(
-                    f"{collection}:feature:{f_hash}:meta",
-                    func_id,
-                    json.dumps(meta_entry),
-                )
+                acc.metas[f_hash][func_id] = json.dumps(meta_entry)
 
             # Mark as indexed (Base ID)
-            pipe.sadd(f"{collection}:indexed:functions", func_id)
+            acc.indexed.append(func_id)
 
             # Execute pipeline in chunks to reduce memory footprint and network overhead
             if (i + 1) % 100 == 0:
+                acc.flush(pipe, collection)
                 pipe.execute()
                 pipe = self.r.pipeline(transaction=False)
 
@@ -120,6 +147,7 @@ class FeatureService:
                         )
                     milvus_data = []
 
+        acc.flush(pipe, collection)
         pipe.execute()
 
         # Final Milvus Flush

--- a/test_index_features_batching.py
+++ b/test_index_features_batching.py
@@ -1,0 +1,116 @@
+"""index_functions must read vec:meta / vec:tf in batched round-trips.
+
+The old code did one blocking GET + one ZRANGE per function, which dominated
+INDEX_FEATURES wall time. This guards both the batching and the writes it emits.
+"""
+
+import json
+
+from bsimvis.app.services.feature_service import FeatureService
+
+
+class StubPipe:
+    def __init__(self, store, stats):
+        self.store = store
+        self.stats = stats
+        self.ops = []
+
+    def get(self, key):
+        self.ops.append(("get", key))
+
+    def zrange(self, key, start, end, withscores=False):
+        self.ops.append(("zrange", key))
+
+    def hgetall(self, key):
+        self.ops.append(("hgetall", key))
+
+    # write side: recorded, no result needed
+    def set(self, key, value):
+        self.ops.append(("w", "set", key))
+
+    def zadd(self, key, mapping):
+        self.ops.append(("w", "zadd", key))
+
+    def zincrby(self, key, amount, member):
+        self.ops.append(("w", "zincrby", key))
+
+    def hset(self, key, field, value):
+        self.ops.append(("w", "hset", key))
+
+    def sadd(self, key, *values):
+        self.ops.append(("w", "sadd", key))
+
+    def execute(self):
+        self.stats["executes"] += 1
+        out = []
+        for op in self.ops:
+            if op[0] == "get":
+                out.append(self.store.get(op[1]))
+            elif op[0] == "zrange":
+                out.append(self.store.get(op[1], []))
+            elif op[0] == "hgetall":
+                out.append(self.store.get(op[1], {}))
+            else:
+                out.append(True)
+        self.ops = []
+        return out
+
+
+class StubRedis:
+    def __init__(self, store):
+        self.store = store
+        self.stats = {"executes": 0, "direct": 0}
+
+    def pipeline(self, transaction=False):
+        return StubPipe(self.store, self.stats)
+
+    def get(self, key):
+        self.stats["direct"] += 1
+        return self.store.get(key)
+
+    def zrange(self, key, start, end, withscores=False):
+        self.stats["direct"] += 1
+        return self.store.get(key, [])
+
+    def sadd(self, key, *values):
+        self.store.setdefault(key, set()).update(values)
+
+
+def test_batched_reads():
+    n = 250
+    store = {}
+    fids = [f"main:function:abc:{i}" for i in range(n)]
+    for fid in fids:
+        store[f"{fid}:vec:meta"] = json.dumps([{"hash": f"h{fid}", "tf": 1}, {"hash": f"g{fid}", "tf": 1}])
+        store[f"{fid}:vec:tf"] = [(f"h{fid}", 2.0)]
+
+    r = StubRedis(store)
+    svc = FeatureService(r)
+    assert svc.index_functions("main", fids) is True
+
+    # No per-function blocking reads outside the pipeline.
+    assert r.stats["direct"] == 0, r.stats
+
+    # 250 funcs / READ_BATCH 100 => 3 read flushes, plus write flushes.
+    assert r.stats["executes"] <= 8, r.stats
+
+    # Features still land in the pending-enrichment set.
+    assert len(store["main:features:pending_enrichment"]) == n
+
+
+def test_missing_data_skipped():
+    store = {}
+    fids = ["main:function:abc:0", "main:function:abc:1"]
+    store[f"{fids[0]}:vec:meta"] = json.dumps([{"hash": "h0", "tf": 1}, {"hash": "g0", "tf": 1}])
+    store[f"{fids[0]}:vec:tf"] = [("h0", 1.0)]
+    # fids[1] has no data at all -> must be skipped, not crash
+
+    r = StubRedis(store)
+    assert FeatureService(r).index_functions("main", fids) is True
+    assert store["main:features:pending_enrichment"] == {"h0"}
+
+
+if __name__ == "__main__":
+    test_batched_reads()
+    test_missing_data_skipped()
+    print("ok")

--- a/test_index_features_batching.py
+++ b/test_index_features_batching.py
@@ -24,21 +24,29 @@ class StubPipe:
     def hgetall(self, key):
         self.ops.append(("hgetall", key))
 
-    # write side: recorded, no result needed
-    def set(self, key, value):
-        self.ops.append(("w", "set", key))
+    # write side: applied to the store so results can be asserted
+    def _w(self, fn):
+        self.stats["cmds"] += 1
+        self.ops.append(("w", fn))
+
+    def mset(self, mapping):
+        self._w(lambda: self.store.update(mapping))
 
     def zadd(self, key, mapping):
-        self.ops.append(("w", "zadd", key))
+        self._w(lambda: self.store.setdefault(key, {}).update(mapping))
 
     def zincrby(self, key, amount, member):
-        self.ops.append(("w", "zincrby", key))
+        def apply():
+            z = self.store.setdefault(key, {})
+            z[member] = z.get(member, 0.0) + amount
 
-    def hset(self, key, field, value):
-        self.ops.append(("w", "hset", key))
+        self._w(apply)
+
+    def hset(self, key, field=None, value=None, mapping=None):
+        self._w(lambda: self.store.setdefault(key, {}).update(mapping or {field: value}))
 
     def sadd(self, key, *values):
-        self.ops.append(("w", "sadd", key))
+        self._w(lambda: self.store.setdefault(key, set()).update(values))
 
     def execute(self):
         self.stats["executes"] += 1
@@ -51,6 +59,7 @@ class StubPipe:
             elif op[0] == "hgetall":
                 out.append(self.store.get(op[1], {}))
             else:
+                op[1]()
                 out.append(True)
         self.ops = []
         return out
@@ -59,7 +68,7 @@ class StubPipe:
 class StubRedis:
     def __init__(self, store):
         self.store = store
-        self.stats = {"executes": 0, "direct": 0}
+        self.stats = {"executes": 0, "direct": 0, "cmds": 0}
 
     def pipeline(self, transaction=False):
         return StubPipe(self.store, self.stats)
@@ -76,26 +85,47 @@ class StubRedis:
         self.store.setdefault(key, set()).update(values)
 
 
-def test_batched_reads():
-    n = 250
+def test_batched_and_correct():
+    """Realistic shape: many functions sharing a small pool of feature hashes."""
+    n, per_func, pool = 250, 40, 60
     store = {}
     fids = [f"main:function:abc:{i}" for i in range(n)]
-    for fid in fids:
-        store[f"{fid}:vec:meta"] = json.dumps([{"hash": f"h{fid}", "tf": 1}, {"hash": f"g{fid}", "tf": 1}])
-        store[f"{fid}:vec:tf"] = [(f"h{fid}", 2.0)]
+    hashes = {}  # fid -> {f_hash: tf}
+    for k, fid in enumerate(fids):
+        hs = {f"h{(k + j) % pool}": float(j + 1) for j in range(per_func)}
+        hashes[fid] = hs
+        store[f"{fid}:vec:meta"] = json.dumps(
+            [{"hash": h, "tf": tf} for h, tf in hs.items()]
+        )
+        store[f"{fid}:vec:tf"] = list(hs.items())
 
     r = StubRedis(store)
-    svc = FeatureService(r)
-    assert svc.index_functions("main", fids) is True
+    assert FeatureService(r).index_functions("main", fids) is True
 
     # No per-function blocking reads outside the pipeline.
     assert r.stats["direct"] == 0, r.stats
 
-    # 250 funcs / READ_BATCH 100 => 3 read flushes, plus write flushes.
-    assert r.stats["executes"] <= 8, r.stats
+    # Naive fan-out would be n*per_func*3 = 30000 commands.
+    assert r.stats["cmds"] < 3000, r.stats
 
-    # Features still land in the pending-enrichment set.
-    assert len(store["main:features:pending_enrichment"]) == n
+    # --- writes must be identical to the un-merged version ---
+    expected_by_tf = {}
+    for fid, hs in hashes.items():
+        for h, tf in hs.items():
+            expected_by_tf[h] = expected_by_tf.get(h, 0.0) + tf
+            assert store[f"main:feature:{h}:functions"][fid] == tf
+            entry = json.loads(store[f"main:feature:{h}:meta"][fid])
+            assert entry["function_id"] == fid and entry["hash"] == h
+    for h, total in expected_by_tf.items():
+        assert abs(store["main:features:by_tf"][h] - total) < 1e-9, h
+
+    assert store["main:indexed:functions"] == set(fids)
+    assert len(store["main:features:pending_enrichment"]) == pool
+    # L2 norm per function
+    fid = fids[0]
+    assert abs(
+        store[f"{fid}:vec:norm"] ** 2 - sum(tf**2 for tf in hashes[fid].values())
+    ) < 1e-6
 
 
 def test_missing_data_skipped():
@@ -111,6 +141,6 @@ def test_missing_data_skipped():
 
 
 if __name__ == "__main__":
-    test_batched_reads()
+    test_batched_and_correct()
     test_missing_data_skipped()
     print("ok")


### PR DESCRIPTION
`INDEX_FEATURES` was one of the pipeline's bottlenecks. Profiling against local kvrocks showed the cost is dominated by the **write fan-out**, with reads and progress reporting second.

Measured per function (500 functions × 40 features), before:

| operation | cost |
|---|---|
| `hset {coll}:feature:{h}:meta` | 1011 µs |
| `zadd {coll}:feature:{h}:functions` | 474 µs |
| `zincrby {coll}:features:by_tf` | 345 µs |
| reads (`GET :vec:meta` + `ZRANGE :vec:tf`) | 209 µs |

## Changes

**1. Merge writes per feature hash** (the big one). Each function emitted one `ZADD` + one `ZINCRBY` + one `HSET` *per feature* — ~120 commands for a 40-feature function. A window of functions is now buffered and collapsed: one `ZADD` with all members, one `ZINCRBY` with the summed tf, one `HSET` with all fields, one `SADD` per window, `MSET` for the norms.

Median of 7 interleaved runs, 500 functions × 40 features:

| distinct feature hashes | before | after | speedup |
|---|---|---|---|
| 1000 | 987 ms | 185 ms | **5.3×** |
| 5000 | 1013 ms | 377 ms | **2.7×** |

**2. Batch reads.** Was 2 serialized round-trips per function; now one pipeline per 100 functions (`_fetch_vec_batch`). 104 ms → 52 ms per 500 functions.

**3. Throttle progress.** `update_progress` fired every 10 functions. Each call does `HSET` + a log write + `HGET parent_id` + one `HGET` per sibling task — measured at 0.5 ms (5 siblings) to 1.3 ms (50 siblings), so a 5000-function job burned ~0.5 s just reporting. It now fires only when the integer percent moves: at most 100 calls regardless of size.

**4. Batch the enrichment `HGETALL`.** In `index_global_features`, features with fewer than 100 occurrences (the common case) each triggered an individual `HGETALL`. Batched into one pipeline per 500-feature chunk.

Rough end-to-end for 500 functions: **~1.15 s → ~0.33 s**.

## Correctness

No behaviour change — same keys, same values. `test_index_features_batching.py` builds 250 functions sharing a pool of feature hashes and asserts the resulting `:functions` zsets, `:meta` hash fields, `by_tf` sums, `indexed:functions` set and L2 norms field by field against a reference computed in Python, plus that no per-function blocking read escapes the pipeline and that the missing-data path still skips cleanly.

Benchmarks used throwaway `benchtmp:` keys, deleted afterwards; no collection data was read or touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)