### PR TITLE
feat(upload): select Ghidra processor/cspec from a validated list

### DIFF
--- a/bsimvis/app/routes/file.py
+++ b/bsimvis/app/routes/file.py
@@ -390,6 +390,16 @@ def upload_raw_binary():
 
         logging.info(f"[*] Received {len(raw_bytes)} bytes for raw upload")
 
+        # Reject a bad language/cspec pair here: otherwise it only fails deep
+        # inside the Ghidra import, after the job has been queued.
+        from bsimvis.app.services.ghidra_lang_service import validate as validate_lang
+
+        lang_error = validate_lang(
+            request.args.get("processor"), request.args.get("cspec")
+        )
+        if lang_error:
+            return {"error": lang_error}, 400
+
         # Get metadata from headers or query params
         collection = request.args.get("collection", "main")
         file_name = request.args.get("file_name", "unknown")

--- a/bsimvis/app/routes/index.py
+++ b/bsimvis/app/routes/index.py
@@ -13,6 +13,14 @@ def get_index_status():
     return stats
 
 
+def get_languages():
+    """Returns the Ghidra language IDs and their valid compiler specs."""
+    from bsimvis.app.services.ghidra_lang_service import get_languages as languages
+
+    result = languages()
+    return {"total": len(result), "languages": result}
+
+
 def get_config():
     """Returns the default configuration values."""
     from bsimvis.app.services.config_service import config_service

--- a/bsimvis/app/services/ghidra_lang_service.py
+++ b/bsimvis/app/services/ghidra_lang_service.py
@@ -1,0 +1,91 @@
+"""Enumerates the Ghidra language IDs and compiler specs of the installed Ghidra.
+
+Read straight from Ghidra's *.ldefs XML files rather than from the JVM: the API
+process never boots Ghidra, and the definitions are exactly what
+DefaultLanguageService exposes at runtime. Reading the install means the list
+stays correct across Ghidra upgrades instead of rotting in a constant.
+"""
+
+import logging
+import os
+import xml.etree.ElementTree as ET
+from functools import lru_cache
+from pathlib import Path
+
+
+def _ghidra_dir():
+    path = os.environ.get("GHIDRA_INSTALL_DIR")
+    return Path(path) if path else None
+
+
+@lru_cache(maxsize=1)
+def get_languages():
+    """Returns [{id, processor, endian, size, variant, description, compilers}].
+
+    compilers is [{id, name}], the compiler specs valid *for that language*.
+    Deprecated languages are skipped, matching
+    getLanguageDescriptions(includeDeprecated=False).
+    """
+    root = _ghidra_dir()
+    if not root or not root.is_dir():
+        return []
+
+    languages = []
+    for ldefs in sorted(root.glob("Ghidra/Processors/*/data/languages/*.ldefs")):
+        try:
+            tree = ET.parse(ldefs)
+        except ET.ParseError as e:
+            logging.warning(f"Skipping unparsable ldefs {ldefs}: {e}")
+            continue
+
+        for lang in tree.getroot().findall("language"):
+            if lang.get("deprecated", "false").lower() == "true":
+                continue
+            lang_id = lang.get("id")
+            if not lang_id:
+                continue
+            desc = lang.findtext("description") or ""
+            languages.append(
+                {
+                    "id": lang_id,
+                    "processor": lang.get("processor"),
+                    "endian": lang.get("endian"),
+                    "size": lang.get("size"),
+                    "variant": lang.get("variant"),
+                    "description": desc.strip(),
+                    "compilers": [
+                        {"id": c.get("id"), "name": c.get("name") or c.get("id")}
+                        for c in lang.findall("compiler")
+                        if c.get("id")
+                    ],
+                }
+            )
+
+    languages.sort(key=lambda x: x["id"])
+    return languages
+
+
+def validate(processor, cspec=None):
+    """Returns an error string if the (processor, cspec) pair is invalid, else None.
+
+    cspec validity is per-language, so the pair is checked together. An unknown
+    install (empty list) validates nothing -- Ghidra stays the final authority.
+    """
+    if not processor:
+        return None
+
+    languages = get_languages()
+    if not languages:
+        return None
+
+    lang = next((l for l in languages if l["id"] == processor), None)
+    if lang is None:
+        near = [l["id"] for l in languages if processor.lower() in l["id"].lower()][:5]
+        hint = f" Did you mean: {', '.join(near)}?" if near else ""
+        return f"Unknown processor '{processor}'.{hint} See /api/index/languages."
+
+    if cspec and cspec not in [c["id"] for c in lang["compilers"]]:
+        valid = ", ".join(c["id"] for c in lang["compilers"]) or "none"
+        return f"Compiler spec '{cspec}' is not valid for '{processor}'. Valid: {valid}."
+
+    return None

--- a/bsimvis/app/static/js/upload.js
+++ b/bsimvis/app/static/js/upload.js
@@ -55,6 +55,21 @@ function renderUploadView(params) {
                             </div>
                         </div>
 
+                        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 20px;">
+                            <div class="form-group">
+                                <label style="display: block; font-size: 0.75rem; color: var(--subtle); margin-bottom: 6px;">Processor</label>
+                                <select id="upload-processor" style="width: 100%; background: #000; border: 1px solid var(--border); color: #fff; padding: 8px; border-radius: 4px; font-size: 0.85rem; cursor: pointer;">
+                                    <option value="">Auto-detect</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label style="display: block; font-size: 0.75rem; color: var(--subtle); margin-bottom: 6px;">Compiler Spec</label>
+                                <select id="upload-cspec" disabled style="width: 100%; background: #000; border: 1px solid var(--border); color: #fff; padding: 8px; border-radius: 4px; font-size: 0.85rem; cursor: pointer;">
+                                    <option value="">Default</option>
+                                </select>
+                            </div>
+                        </div>
+
                         <div class="form-group" style="margin-bottom: 20px;">
                             <label style="display: block; font-size: 0.75rem; color: var(--subtle); margin-bottom: 6px;">Tags (Global)</label>
                             <input type="text" id="upload-tags" placeholder="Malware, Linux, MIPS..." style="width: 100%; background: #000; border: 1px solid var(--border); color: #fff; padding: 8px; border-radius: 4px; font-size: 0.85rem;">
@@ -113,6 +128,49 @@ function renderUploadView(params) {
     setupUploadEvents();
     updateFileList();
     populateUploadCollectionDropdown(collection);
+    populateUploadLanguageDropdowns();
+}
+
+// Compiler specs are valid per-language, so the cspec list is rebuilt from the
+// selected processor rather than being a flat list of every spec Ghidra has.
+async function populateUploadLanguageDropdowns() {
+    const procSelect = document.getElementById('upload-processor');
+    const cspecSelect = document.getElementById('upload-cspec');
+    if (!procSelect || !cspecSelect) return;
+
+    let languages = [];
+    try {
+        const res = await fetch('/api/index/languages');
+        if (res.ok) languages = (await res.json()).languages || [];
+    } catch (e) {
+        console.warn('Failed to load Ghidra languages', e);
+    }
+
+    if (!languages.length) {
+        procSelect.disabled = true;
+        procSelect.title = 'Ghidra install not reachable from the API';
+        return;
+    }
+
+    for (const lang of languages) {
+        const opt = document.createElement('option');
+        opt.value = lang.id;
+        opt.innerText = lang.description ? `${lang.id} — ${lang.description}` : lang.id;
+        procSelect.appendChild(opt);
+    }
+
+    procSelect.onchange = () => {
+        const lang = languages.find(l => l.id === procSelect.value);
+        cspecSelect.innerHTML = '<option value="">Default</option>';
+        cspecSelect.disabled = !lang;
+        if (!lang) return;
+        for (const c of lang.compilers) {
+            const opt = document.createElement('option');
+            opt.value = c.id;
+            opt.innerText = c.name === c.id ? c.id : `${c.id} (${c.name})`;
+            cspecSelect.appendChild(opt);
+        }
+    };
 }
 
 function setupUploadEvents() {
@@ -237,6 +295,8 @@ async function startBatchUpload() {
     const batchName = document.getElementById('upload-batch-name').value || 'Manual Upload';
     const profile = document.getElementById('upload-profile').value;
     const minFuncLen = document.getElementById('upload-min-func-len').value;
+    const processor = document.getElementById('upload-processor').value;
+    const cspec = document.getElementById('upload-cspec').value;
     const tags = document.getElementById('upload-tags').value.split(',').map(t => t.trim()).filter(t => t);
     const relatedMd5s = document.getElementById('upload-related-md5').value.split(',').map(m => m.trim()).filter(m => m);
     
@@ -283,6 +343,8 @@ async function startBatchUpload() {
             url.searchParams.set('batch_name', batchName);
             url.searchParams.set('profile', profile);
             url.searchParams.set('min_func_len', minFuncLen);
+            if (processor) url.searchParams.set('processor', processor);
+            if (processor && cspec) url.searchParams.set('cspec', cspec);
             tags.forEach(t => url.searchParams.append('tags', t));
             relatedMd5s.forEach(m => url.searchParams.append('related_md5', m));
 

--- a/bsimvis/app/static/js/upload.js
+++ b/bsimvis/app/static/js/upload.js
@@ -58,15 +58,19 @@ function renderUploadView(params) {
                         <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 15px; margin-bottom: 20px;">
                             <div class="form-group">
                                 <label style="display: block; font-size: 0.75rem; color: var(--subtle); margin-bottom: 6px;">Processor</label>
-                                <select id="upload-processor" style="width: 100%; background: #000; border: 1px solid var(--border); color: #fff; padding: 8px; border-radius: 4px; font-size: 0.85rem; cursor: pointer;">
-                                    <option value="">Auto-detect</option>
-                                </select>
+                                <div style="position: relative;">
+                                    <input type="text" id="upload-processor-search" autocomplete="off" placeholder="Auto-detect — click to browse" style="width: 100%; background: #000; border: 1px solid var(--border); color: #fff; padding: 8px; border-radius: 4px; font-size: 0.85rem;">
+                                    <input type="hidden" id="upload-processor" value="">
+                                    <div id="upload-processor-list" style="display: none; position: absolute; z-index: 50; top: 100%; left: 0; right: 0; max-height: 260px; overflow-y: auto; background: #000; border: 1px solid var(--border); border-radius: 4px; margin-top: 2px; box-shadow: 0 6px 18px rgba(0,0,0,0.6);"></div>
+                                </div>
+                                <div id="upload-processor-hint" style="font-size: 0.7rem; color: var(--subtle); margin-top: 4px; min-height: 1em;"></div>
                             </div>
                             <div class="form-group">
                                 <label style="display: block; font-size: 0.75rem; color: var(--subtle); margin-bottom: 6px;">Compiler Spec</label>
                                 <select id="upload-cspec" disabled style="width: 100%; background: #000; border: 1px solid var(--border); color: #fff; padding: 8px; border-radius: 4px; font-size: 0.85rem; cursor: pointer;">
                                     <option value="">Default</option>
                                 </select>
+                                <div id="upload-cspec-hint" style="font-size: 0.7rem; color: var(--subtle); margin-top: 4px; min-height: 1em;"></div>
                             </div>
                         </div>
 
@@ -131,46 +135,130 @@ function renderUploadView(params) {
     populateUploadLanguageDropdowns();
 }
 
-// Compiler specs are valid per-language, so the cspec list is rebuilt from the
-// selected processor rather than being a flat list of every spec Ghidra has.
-async function populateUploadLanguageDropdowns() {
-    const procSelect = document.getElementById('upload-processor');
-    const cspecSelect = document.getElementById('upload-cspec');
-    if (!procSelect || !cspecSelect) return;
+// ~170 languages, so the processor picker is a filterable combobox: the full
+// list is visible on click and narrows as you type. Compiler specs are valid
+// per-language, so the cspec <select> is rebuilt from the chosen processor.
+let uploadLanguages = [];
 
-    let languages = [];
+async function populateUploadLanguageDropdowns() {
+    const search = document.getElementById('upload-processor-search');
+    const hidden = document.getElementById('upload-processor');
+    if (!search || !hidden) return;
+
     try {
         const res = await fetch('/api/index/languages');
-        if (res.ok) languages = (await res.json()).languages || [];
+        if (res.ok) uploadLanguages = (await res.json()).languages || [];
     } catch (e) {
         console.warn('Failed to load Ghidra languages', e);
     }
 
-    if (!languages.length) {
-        procSelect.disabled = true;
-        procSelect.title = 'Ghidra install not reachable from the API';
+    if (!uploadLanguages.length) {
+        search.disabled = true;
+        search.placeholder = 'Auto-detect';
+        search.title = 'Ghidra install not reachable from the API';
         return;
     }
 
-    for (const lang of languages) {
-        const opt = document.createElement('option');
-        opt.value = lang.id;
-        opt.innerText = lang.description ? `${lang.id} — ${lang.description}` : lang.id;
-        procSelect.appendChild(opt);
+    search.placeholder = `Auto-detect \u2014 click to browse (${uploadLanguages.length})`;
+    search.onfocus = () => renderProcessorOptions();
+    search.oninput = () => {
+        // Typing invalidates the previous pick until a row is chosen again.
+        hidden.value = '';
+        refreshUploadCspecs();
+        renderProcessorOptions();
+    };
+    search.onkeydown = (e) => {
+        if (e.key === 'Escape') document.getElementById('upload-processor-list').style.display = 'none';
+    };
+
+    // Clicking outside closes the panel; mousedown on a row fires first.
+    document.addEventListener('click', (e) => {
+        const panel = document.getElementById('upload-processor-list');
+        if (!panel) return;
+        if (e.target !== search && !panel.contains(e.target)) panel.style.display = 'none';
+    });
+
+    renderProcessorOptions();
+}
+
+function escapeHtmlAttr(s) {
+    return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
+
+function renderProcessorOptions() {
+    const search = document.getElementById('upload-processor-search');
+    const panel = document.getElementById('upload-processor-list');
+    if (!search || !panel) return;
+
+    const q = search.value.trim().toLowerCase();
+    // Match id and description, so "arm" and "Intel" both find their languages.
+    const matches = uploadLanguages.filter(
+        l => !q || l.id.toLowerCase().includes(q) || (l.description || '').toLowerCase().includes(q)
+    );
+
+    panel.style.display = 'block';
+    if (!matches.length) {
+        panel.innerHTML = '<div style="padding: 8px; font-size: 0.8rem; color: var(--subtle);">No matching language</div>';
+        return;
     }
 
-    procSelect.onchange = () => {
-        const lang = languages.find(l => l.id === procSelect.value);
-        cspecSelect.innerHTML = '<option value="">Default</option>';
-        cspecSelect.disabled = !lang;
-        if (!lang) return;
-        for (const c of lang.compilers) {
-            const opt = document.createElement('option');
-            opt.value = c.id;
-            opt.innerText = c.name === c.id ? c.id : `${c.id} (${c.name})`;
-            cspecSelect.appendChild(opt);
-        }
-    };
+    panel.innerHTML =
+        '<div data-lang-id="" style="padding: 7px 9px; font-size: 0.8rem; color: var(--subtle); cursor: pointer; border-bottom: 1px solid var(--border);">Auto-detect</div>' +
+        matches
+            .map(
+                l => `<div data-lang-id="${escapeHtmlAttr(l.id)}" style="padding: 7px 9px; font-size: 0.8rem; cursor: pointer; border-bottom: 1px solid rgba(255,255,255,0.04);">
+                        <div style="color: #fff;">${escapeHtmlAttr(l.id)}</div>
+                        <div style="color: var(--subtle); font-size: 0.7rem;">${escapeHtmlAttr(l.description || '')}</div>
+                      </div>`
+            )
+            .join('');
+
+    for (const row of panel.querySelectorAll('[data-lang-id]')) {
+        row.onmouseenter = () => (row.style.background = 'rgba(255,255,255,0.06)');
+        row.onmouseleave = () => (row.style.background = 'transparent');
+        row.onmousedown = () => {
+            selectUploadProcessor(row.getAttribute('data-lang-id'));
+            panel.style.display = 'none';
+        };
+    }
+}
+
+function selectUploadProcessor(langId) {
+    const search = document.getElementById('upload-processor-search');
+    const hidden = document.getElementById('upload-processor');
+    hidden.value = langId || '';
+    search.value = langId || '';
+    refreshUploadCspecs();
+}
+
+function refreshUploadCspecs() {
+    const hidden = document.getElementById('upload-processor');
+    const cspecSelect = document.getElementById('upload-cspec');
+    const procHint = document.getElementById('upload-processor-hint');
+    const cspecHint = document.getElementById('upload-cspec-hint');
+    if (!hidden || !cspecSelect) return;
+
+    const lang = uploadLanguages.find(l => l.id === hidden.value);
+
+    procHint.innerText = lang ? lang.description || '' : '';
+
+    // Changing or clearing the processor invalidates the selected cspec.
+    cspecSelect.innerHTML = '<option value="">Default</option>';
+    cspecSelect.disabled = !lang;
+    if (!lang) {
+        cspecHint.innerText = '';
+        return;
+    }
+
+    for (const c of lang.compilers) {
+        const opt = document.createElement('option');
+        opt.value = c.id;
+        opt.innerText = c.name && c.name !== c.id ? `${c.id} (${c.name})` : c.id;
+        cspecSelect.appendChild(opt);
+    }
+    cspecHint.innerText = lang.compilers.length
+        ? `${lang.compilers.length} spec(s) available`
+        : 'No compiler specs for this language';
 }
 
 function setupUploadEvents() {
@@ -295,8 +383,19 @@ async function startBatchUpload() {
     const batchName = document.getElementById('upload-batch-name').value || 'Manual Upload';
     const profile = document.getElementById('upload-profile').value;
     const minFuncLen = document.getElementById('upload-min-func-len').value;
-    const processor = document.getElementById('upload-processor').value;
-    const cspec = document.getElementById('upload-cspec').value;
+    const processor = document.getElementById('upload-processor').value.trim();
+    const cspec = document.getElementById('upload-cspec').value.trim();
+
+    // The API validates the pair too; this just avoids a round-trip per file.
+    const lang = uploadLanguages.find(l => l.id === processor);
+    if (processor && !lang) {
+        if (typeof showToast === 'function') showToast(`Unknown processor '${processor}'`, 'warning');
+        return;
+    }
+    if (cspec && lang && !lang.compilers.some(c => c.id === cspec)) {
+        if (typeof showToast === 'function') showToast(`'${cspec}' is not a valid compiler spec for ${processor}`, 'warning');
+        return;
+    }
     const tags = document.getElementById('upload-tags').value.split(',').map(t => t.trim()).filter(t => t);
     const relatedMd5s = document.getElementById('upload-related-md5').value.split(',').map(m => m.trim()).filter(m => m);
     

--- a/bsimvis/app/swagger.py
+++ b/bsimvis/app/swagger.py
@@ -341,6 +341,15 @@ class IndexStatus(Resource):
         return get_index_status()
 
 
+@ns_index.route("/languages")
+class IndexLanguages(Resource):
+    def get(self):
+        """Lists Ghidra language IDs and the compiler specs valid for each."""
+        from bsimvis.app.routes.index import get_languages
+
+        return get_languages()
+
+
 @ns_index.route("/config")
 class IndexConfig(Resource):
     def get(self):

--- a/test_api_endpoints.py
+++ b/test_api_endpoints.py
@@ -439,6 +439,78 @@ def resolve_ids():
 
 
 # ---------------------------------------------------------------------------
+# Ghidra language / compiler-spec listing and upload validation
+# ---------------------------------------------------------------------------
+def test_ghidra_languages():
+    """Checks /api/index/languages and the processor/cspec validation on upload."""
+    body = test_endpoint("GET", "/api/index/languages")
+    langs = (body or {}).get("languages") or []
+
+    if not check(
+        "languages endpoint returns entries",
+        langs,
+        "empty list -- is GHIDRA_INSTALL_DIR set for the API process?",
+    ):
+        return
+
+    check(
+        "languages carry id + per-language compilers",
+        all(l.get("id") and isinstance(l.get("compilers"), list) for l in langs),
+    )
+    check(
+        "x86:LE:64:default is listed",
+        any(l["id"] == "x86:LE:64:default" for l in langs),
+    )
+
+    x86 = next((l for l in langs if l["id"] == "x86:LE:64:default"), None)
+    if x86:
+        check(
+            "x86:LE:64:default offers a gcc compiler spec",
+            any(c["id"] == "gcc" for c in x86["compilers"]),
+            f"got: {[c['id'] for c in x86['compilers']]}",
+        )
+
+    # Upload validation: bad processor, and a cspec valid for another language
+    # but not this one, must both be rejected before the job is queued.
+    bad_proc = test_endpoint(
+        "POST",
+        "/api/file/upload",
+        params={
+            "collection": COLLECTION,
+            "file_name": "lang_validation.bin",
+            "processor": "nonexistent:LE:64:default",
+        },
+        raw_body=b"\x7fELF not-a-real-binary",
+        expected_ok=False,
+        label="POST /api/file/upload?processor=<invalid> (expect 400)",
+    )
+    check(
+        "invalid processor rejected with an error",
+        isinstance(bad_proc, dict) and "error" in bad_proc,
+        str(bad_proc)[:200],
+    )
+
+    bad_cspec = test_endpoint(
+        "POST",
+        "/api/file/upload",
+        params={
+            "collection": COLLECTION,
+            "file_name": "lang_validation.bin",
+            "processor": "x86:LE:64:default",
+            "cspec": "not_a_cspec",
+        },
+        raw_body=b"\x7fELF not-a-real-binary",
+        expected_ok=False,
+        label="POST /api/file/upload?cspec=<invalid> (expect 400)",
+    )
+    check(
+        "invalid cspec for the language rejected",
+        isinstance(bad_cspec, dict) and "error" in bad_cspec,
+        str(bad_cspec)[:200],
+    )
+
+
+# ---------------------------------------------------------------------------
 # Step 4 – Full endpoint sweep
 # ---------------------------------------------------------------------------
 def run_all_tests():
@@ -785,6 +857,7 @@ def run_all_tests():
     # ── Misc (index config / details) ──────────────────────────────────────
     print(_color("\n  [Misc]", BOLD))
     test_endpoint("GET", "/api/index/config")
+    test_ghidra_languages()
     if file_md5:
         test_endpoint(
             "GET",


### PR DESCRIPTION
Closes #33.

## What

- **`GET /api/index/languages`** — lists every Ghidra language ID with the compiler specs valid *for that language* (`{total, languages:[{id, processor, endian, size, variant, description, compilers:[{id,name}]}]}`).
  Implemented in `bsimvis/app/services/ghidra_lang_service.py` by parsing Ghidra's `*.ldefs` XML under `GHIDRA_INSTALL_DIR`: the API process never boots a JVM, and reading the install means the list follows Ghidra upgrades instead of rotting in a constant. Deprecated languages are skipped, matching `getLanguageDescriptions(false)`. `lru_cache`d — static per install.
- **Upload UI** (`upload.js`) — processor + cspec dropdowns fed by that endpoint. cspec validity is per-language, so its list is rebuilt from the selected processor. Auto-detect remains the default; the params are only sent when a processor is chosen. Endpoint unreachable → processor select disables, upload keeps working as before.
- **Validation** — `/api/file/upload` checks the (processor, cspec) *pair* and returns 400 naming valid values, before the raw file is stored or the job queued. Previously a typo surfaced as an opaque failure inside analysis.

## Test

Extended `test_api_endpoints.py` (existing suite, `[Misc]` section): endpoint shape, `x86:LE:64:default` present with a `gcc` cspec, and 400s for an invalid processor and for a cspec valid elsewhere but not for the selected language.

`./scripts/wt-test.sh` on this worktree: **287/287 passed, 0 failed** — full stack, including the 8 new checks.

Not covered: the dropdowns were not exercised in a browser; backend contract they consume is tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)