### PR TITLE
feat(bsim): configurable signature settings + BSim feature weighting

### DIFF
--- a/bsimvis/app/routes/function_similarity.py
+++ b/bsimvis/app/routes/function_similarity.py
@@ -1,5 +1,6 @@
 import json
 from flask import request
+from bsimvis.app.services import bsim_profiles
 from bsimvis.app.services.similarity_service import SimilarityService
 
 
@@ -42,11 +43,21 @@ def similarity_api():
         from bsimvis.app.services.milvus_service import milvus_service
 
         service = SimilarityService()
-        algorithms = ["jaccard", "unweighted_cosine"]
-        if milvus_service.enabled:
-            algorithms.append("milvus_sparse")
+        # `algo` opts in to extra algorithms (comma-separated). weighted_cosine is
+        # not returned by default: it is unbuilt, so every request would score it
+        # on demand, and it raises on a collection whose features were extracted
+        # under different signature settings.
+        requested = request.args.get("algo") or request.args.get("algos")
+        if requested:
+            algorithms = [a.strip() for a in requested.split(",") if a.strip()]
+        else:
+            algorithms = ["jaccard", "unweighted_cosine"]
+            if milvus_service.enabled:
+                algorithms.append("milvus_sparse")
 
         scores = {}
+        significance = {}
+        errors = {}
 
         if pool_id:
             pass  # keep collection as f"global:pool:{pool_id}:col:{collection}"
@@ -70,6 +81,22 @@ def similarity_api():
         user_tags = []
 
         for algo in algorithms:
+            base_algo, _ = bsim_profiles.parse_algo(algo)
+            if base_algo == "weighted_cosine":
+                # Never cached (weighted builds do not exist yet), so compute the
+                # pair directly and report significance alongside the score.
+                try:
+                    sim, sig = service.calculate_exact_score(
+                        id1, id2, algo=algo, with_significance=True
+                    )
+                    scores[algo] = sim
+                    significance[algo] = sig
+                except (ValueError, OSError) as e:
+                    # Mask mismatch, unknown profile, or a missing weights table.
+                    errors[algo] = str(e)
+                    scores[algo] = None
+                continue
+
             # Use service to get score, passing the resolved collection namespace
             score = service.get_pair_score(id1, id2, algo=algo, collection=collection)
             scores[algo] = score
@@ -99,7 +126,7 @@ def similarity_api():
                 source = "on-demand"
                 break
 
-        return {
+        result = {
             "id1": id1,
             "id2": id2,
             "scores": scores,
@@ -107,6 +134,13 @@ def similarity_api():
             "user_tags": user_tags,
             "source": source,
         }
+        # Only weighted_cosine defines a significance; omit the keys entirely
+        # rather than padding every response with nulls.
+        if significance:
+            result["significance"] = significance
+        if errors:
+            result["errors"] = errors
+        return result
 
     except Exception as e:
         return {"detail": f"Error retrieving similarity: {str(e)}"}, 500

--- a/bsimvis/app/routes/similarity.py
+++ b/bsimvis/app/routes/similarity.py
@@ -2,7 +2,10 @@ import json
 
 from flask import request
 from bsimvis.app.services.job_service import JobService, JobType
-from bsimvis.app.services.similarity_service import SimilarityService
+from bsimvis.app.services.similarity_service import (
+    SimilarityService,
+    assert_buildable_algo,
+)
 from bsimvis.app.services.milvus_service import milvus_service
 from bsimvis.app.services.redis_client import get_redis
 from bsimvis.app.services.index_service import normalize_tags
@@ -100,6 +103,12 @@ def build_similarity():
     if algo is None:
         algo = config_service.get("similarity.algo", "unweighted_cosine")
 
+    # Reject before queueing: the build path cannot compute every algorithm.
+    try:
+        assert_buildable_algo(algo)
+    except ValueError as e:
+        return {"error": str(e)}, 400
+
     if not md5 and not batch_uuid and not data.get("all"):
         return {"error": "md5, batch, or all required"}, 400
 
@@ -164,6 +173,12 @@ def rebuild_similarity():
     algo = data.get("algo")
     if algo is None:
         algo = config_service.get("similarity.algo", "unweighted_cosine")
+
+    # Reject before queueing: the build path cannot compute every algorithm.
+    try:
+        assert_buildable_algo(algo)
+    except ValueError as e:
+        return {"error": str(e)}, 400
 
     if not md5 and not batch_uuid and not data.get("all"):
         return {"error": "md5, batch, or all required"}, 400

--- a/bsimvis/app/services/bsim_profiles.py
+++ b/bsimvis/app/services/bsim_profiles.py
@@ -1,0 +1,270 @@
+"""BSim signature-settings profiles.
+
+A profile pairs a decompiler signature-settings mask with the weights table that
+belongs to it. The two cannot be derived from each other: four of the five weight
+tables Ghidra ships declare `settings="0x49"`, so the mask alone does not identify
+a file. Ghidra resolves the pairing through database template configs
+(``data/medium_nosize.xml`` and friends); we make it explicit in config instead.
+
+See ``doc/bsim_signature_settings.md`` for what the mask bits mean.
+"""
+
+import logging
+import os
+from pathlib import Path
+from xml.etree import ElementTree
+
+from bsimvis.app.services.config_service import config_service
+
+# Signature modifier flags, from Ghidra's GraphSigManager::Mods
+# (Features/Decompiler/src/decompile/cpp/signature.hh:269-274).
+SIG_COLLAPSE_SIZE = 0x1
+SIG_COLLAPSE_INDNOISE = 0x2
+SIG_DONOTUSE_CONST = 0x10
+SIG_DONOTUSE_INPUT = 0x20
+SIG_DONOTUSE_PERSIST = 0x40
+
+FLAG_NAMES = {
+    SIG_COLLAPSE_SIZE: "SIG_COLLAPSE_SIZE",
+    SIG_COLLAPSE_INDNOISE: "SIG_COLLAPSE_INDNOISE",
+    SIG_DONOTUSE_CONST: "SIG_DONOTUSE_CONST",
+    SIG_DONOTUSE_INPUT: "SIG_DONOTUSE_INPUT",
+    SIG_DONOTUSE_PERSIST: "SIG_DONOTUSE_PERSIST",
+}
+
+# Bit 0 is a check bit and the flags start at bit 2, so the set of legal masks is
+# (all_flags << 2) | 1. Mirrors GraphSigManager::testSettings (signature.cc:914-924).
+_ALL_FLAGS = (
+    SIG_COLLAPSE_SIZE
+    | SIG_COLLAPSE_INDNOISE
+    | SIG_DONOTUSE_CONST
+    | SIG_DONOTUSE_INPUT
+    | SIG_DONOTUSE_PERSIST
+)
+VALID_SETTINGS_MASK = (_ALL_FLAGS << 2) | 1  # 0x1CD
+
+DEFAULT_PROFILE_NAME = "nosize"
+
+# Shipped with Ghidra. Used when config declares no profiles of its own.
+BUILTIN_PROFILES = {
+    "nosize": {"settings": 0x4D, "weights": "lshweights_nosize.xml"},
+    "sized_32": {"settings": 0x49, "weights": "lshweights_32.xml"},
+    "sized_64": {"settings": 0x49, "weights": "lshweights_64.xml"},
+    "sized_64_32": {"settings": 0x49, "weights": "lshweights_64_32.xml"},
+    "cpool": {"settings": 0x49, "weights": "lshweights_cpool.xml"},
+}
+
+
+class ProfileError(ValueError):
+    """Raised for a malformed profile, an illegal mask, or a mismatched table."""
+
+
+def test_settings(mask):
+    """True if `mask` is a legal argument for setSignatureSettings.
+
+    Mirrors GraphSigManager::testSettings: zero is rejected, and no bit outside
+    VALID_SETTINGS_MASK may be set.
+    """
+    if not isinstance(mask, int) or isinstance(mask, bool):
+        return False
+    if mask == 0:
+        return False
+    return (mask & ~VALID_SETTINGS_MASK) == 0
+
+
+def decode_settings(mask):
+    """Return the flag names enabled by `mask`, decoding bit 0 / the >>2 shift."""
+    if not test_settings(mask):
+        raise ProfileError(
+            f"Invalid signature settings {mask:#x}: must be non-zero and set no bit "
+            f"outside {VALID_SETTINGS_MASK:#x}"
+        )
+    sigmods = mask >> 2
+    return [name for bit, name in sorted(FLAG_NAMES.items()) if sigmods & bit]
+
+
+class BsimProfile:
+    """A validated (settings mask, weights table) pairing."""
+
+    def __init__(self, name, settings, weights_path):
+        self.name = name
+        self.settings = settings
+        self.weights_path = weights_path
+
+    @property
+    def flags(self):
+        return decode_settings(self.settings)
+
+    def __repr__(self):
+        return (
+            f"BsimProfile(name={self.name!r}, settings={self.settings:#x}, "
+            f"weights_path={str(self.weights_path)!r})"
+        )
+
+
+def _ghidra_data_dir():
+    """Directory holding Ghidra's shipped lshweights_*.xml tables."""
+    configured = config_service.get("bsim.weights_dir")
+    if configured:
+        return Path(configured)
+
+    root = config_service.get("ghidra.install_dir") or os.environ.get("GHIDRA_INSTALL_DIR")
+    if root:
+        return Path(root) / "Ghidra" / "Features" / "BSim" / "data"
+
+    # Fall back to the pinned install in the repo's bin/ (not tracked in git, but
+    # that is where install_ghidra.sh puts it).
+    for candidate in sorted(Path("bin").glob("ghidra_*"), reverse=True):
+        data = candidate / "Ghidra" / "Features" / "BSim" / "data"
+        if data.is_dir():
+            return data
+    return Path("bin")
+
+
+def _resolve_weights_path(weights):
+    """Resolve a profile's `weights` entry to a concrete path.
+
+    A bare filename resolves against Ghidra's data directory; anything with a
+    separator is treated as a repo-relative (or absolute) path so custom tables
+    can live in the project.
+    """
+    path = Path(weights)
+    if path.is_absolute() or len(path.parts) > 1:
+        return path
+    return _ghidra_data_dir() / path
+
+
+def weights_file_settings(path):
+    """Read the `settings` attribute the weights table declares for itself."""
+    try:
+        root = ElementTree.parse(path).getroot()
+    except (OSError, ElementTree.ParseError) as exc:
+        raise ProfileError(f"Cannot read weights table {path}: {exc}") from exc
+
+    declared = root.get("settings")
+    if declared is None:
+        raise ProfileError(f"Weights table {path} has no 'settings' attribute")
+    try:
+        return int(declared, 16 if declared.lower().startswith("0x") else 10)
+    except ValueError as exc:
+        raise ProfileError(
+            f"Weights table {path} declares unparseable settings {declared!r}"
+        ) from exc
+
+
+def _configured_profiles():
+    profiles = config_service.get("bsim.profiles")
+    if isinstance(profiles, dict) and profiles:
+        return profiles
+    return BUILTIN_PROFILES
+
+
+def get_profile(name=None, verify_weights=True):
+    """Load and validate a profile by name (default: the configured one).
+
+    Validates that the mask is legal and that the weights table declares the same
+    mask. A mismatch is fatal: scoring with a table built for different signature
+    settings silently produces meaningless numbers.
+    """
+    if name is None:
+        name = config_service.get("bsim.profile", DEFAULT_PROFILE_NAME)
+
+    profiles = _configured_profiles()
+    entry = profiles.get(name)
+    if entry is None:
+        raise ProfileError(
+            f"Unknown BSim profile {name!r}; configured profiles: "
+            f"{sorted(profiles)}"
+        )
+
+    settings = entry.get("settings")
+    if isinstance(settings, str):
+        settings = int(settings, 16 if settings.lower().startswith("0x") else 10)
+    if not test_settings(settings):
+        raise ProfileError(
+            f"Profile {name!r} has invalid signature settings {settings!r}: must be "
+            f"non-zero and set no bit outside {VALID_SETTINGS_MASK:#x}"
+        )
+
+    weights = entry.get("weights")
+    if not weights:
+        raise ProfileError(f"Profile {name!r} declares no weights table")
+    weights_path = _resolve_weights_path(weights)
+
+    if verify_weights:
+        declared = weights_file_settings(weights_path)
+        if declared != settings:
+            raise ProfileError(
+                f"Profile {name!r} pairs settings {settings:#x} with {weights_path}, "
+                f"which declares {declared:#x}. Refusing to score with a weights "
+                f"table built for different signature settings."
+            )
+
+    return BsimProfile(name, settings, weights_path)
+
+
+def parse_algo(algo):
+    """Split an algorithm name into ``(base, profile_name_or_None)``.
+
+    Weighted scores are namespaced by the profile that produced them
+    (``weighted_cosine:nosize``) so that changing profile builds a new score set
+    rather than silently overwriting one computed under different weights.
+    """
+    if algo and ":" in algo:
+        base, _, profile = algo.partition(":")
+        return base, (profile or None)
+    return algo, None
+
+
+def qualified_algo(base, profile_name=None):
+    """Inverse of `parse_algo`: build the namespaced algorithm name."""
+    if profile_name is None:
+        profile_name = config_service.get("bsim.profile", DEFAULT_PROFILE_NAME)
+    return f"{base}:{profile_name}"
+
+
+def get_signature_settings():
+    """The mask the decompiler should use, without touching the weights table.
+
+    Feature extraction needs the mask but not the weights, and runs on hosts where
+    the table may be absent; fall back to the default rather than failing ingest.
+    """
+    try:
+        return get_profile(verify_weights=False).settings
+    except ProfileError as exc:
+        fallback = BUILTIN_PROFILES[DEFAULT_PROFILE_NAME]["settings"]
+        logging.warning(
+            f"[bsim] Falling back to signature settings {fallback:#x}: {exc}"
+        )
+        return fallback
+
+
+def demo():
+    """Self-check: mask validation and decoding."""
+    assert test_settings(0x4D)
+    assert test_settings(0x49)
+    assert not test_settings(0), "zero must be rejected"
+    assert not test_settings(0x2), "bit 1 is not a legal flag position"
+    assert not test_settings(0x1CD | 0x200), "bits outside the mask are illegal"
+    # Ghidra permits bit 0 but does not require it, so 0x4C is legal.
+    assert test_settings(0x4C)
+    assert not test_settings(True), "bools are not masks"
+
+    assert decode_settings(0x4D) == [
+        "SIG_COLLAPSE_SIZE",
+        "SIG_COLLAPSE_INDNOISE",
+        "SIG_DONOTUSE_CONST",
+    ]
+    # 0x49 is the sized configuration: the same minus SIG_COLLAPSE_SIZE.
+    assert decode_settings(0x49) == ["SIG_COLLAPSE_INDNOISE", "SIG_DONOTUSE_CONST"]
+    assert 0x4D >> 2 == 0x13
+
+    assert parse_algo("weighted_cosine:nosize") == ("weighted_cosine", "nosize")
+    assert parse_algo("unweighted_cosine") == ("unweighted_cosine", None)
+    assert qualified_algo("weighted_cosine", "my_go_idf") == "weighted_cosine:my_go_idf"
+
+    print("bsim_profiles demo OK")
+
+
+if __name__ == "__main__":
+    demo()

--- a/bsimvis/app/services/bsim_weights.py
+++ b/bsimvis/app/services/bsim_weights.py
@@ -1,0 +1,270 @@
+"""BSim feature weighting.
+
+Transcribed from Ghidra's reference implementation, the PostgreSQL extension in
+``Ghidra/Features/BSim/src/lshvector/c/weights.c``:
+
+* ``lsh_calc_weights`` (weights.c:231) -- per-feature coefficient and vector length
+* ``lsh_compare_internal`` (weights.c:404) -- similarity *and* significance
+* ``update_norms`` (weights.c:57) -- how ``scale`` is folded in
+
+Two details are easy to get wrong and are load-bearing:
+
+1. The ``count`` in ``<idflookup>`` is an *index* into the idf curve, not a document
+   frequency. A hash absent from the table resolves to index 0, which is the
+   *largest* weight -- so an unseen feature is treated as maximally rare.
+2. The dot product uses the coefficient of whichever side has the smaller ``tf``,
+   squared -- not ``coeff_a * coeff_b``. Because ``coeff`` already folds in the tf
+   curve, this counts only the shared multiplicity. The two rules agree whenever
+   ``tf_a == tf_b``, which is the common case, so a wrong implementation looks
+   right until it doesn't.
+"""
+
+import math
+from xml.etree import ElementTree
+
+IDF_SIZE = 512
+TF_SIZE = 64
+
+
+def _as_hash(key):
+    """Normalize a feature hash to int.
+
+    Stored vectors key features by bare lowercase hex (``hex(h & 0xFFFFFFFF)[2:]``,
+    ghidra_service.py), while the weights tables write ``0x``-prefixed hex.
+    """
+    if isinstance(key, int):
+        return key
+    if isinstance(key, bytes):
+        key = key.decode()
+    return int(key, 16)
+
+
+class WeightTable:
+    """A parsed lshweights_*.xml table."""
+
+    def __init__(self, idf, tf, scale, addend, weightnorm, probflip, probdiff, lookup):
+        self.scale = scale
+        self.addend = addend
+        # Loaded and rescaled by Ghidra but never read by lsh_compare_internal.
+        # Kept for fidelity; deliberately unused.
+        self.weightnorm = weightnorm
+        self.lookup = lookup
+
+        # update_norms (weights.c:62-69): the probability terms are premultiplied
+        # by scale, and every idf weight by sqrt(scale).
+        scale_sqrt = math.sqrt(scale)
+        self.idfweight = [v * scale_sqrt for v in idf]
+        self.tfweight = list(tf)
+        self.probflip0, self.probflip1 = (p * scale for p in probflip)
+        self.probdiff0, self.probdiff1 = (p * scale for p in probdiff)
+
+    @classmethod
+    def from_file(cls, path):
+        root = ElementTree.parse(path).getroot()
+        factory = root.find("weightfactory")
+        if factory is None:
+            raise ValueError(f"{path}: no <weightfactory> element")
+
+        idf = [float(e.text) for e in factory.findall("idf")]
+        tf = [float(e.text) for e in factory.findall("tf")]
+        if len(idf) < IDF_SIZE:
+            raise ValueError(f"{path}: expected >= {IDF_SIZE} <idf> entries, got {len(idf)}")
+        if len(tf) < TF_SIZE:
+            raise ValueError(f"{path}: expected >= {TF_SIZE} <tf> entries, got {len(tf)}")
+
+        def scalar(tag):
+            el = factory.find(tag)
+            if el is None:
+                raise ValueError(f"{path}: no <{tag}> element")
+            return float(el.text)
+
+        lookup = {}
+        for el in root.iter("hash"):
+            lookup[_as_hash(el.text.strip())] = int(el.get("count", 0))
+
+        return cls(
+            idf=idf,
+            tf=tf,
+            scale=float(factory.get("scale")),
+            addend=float(factory.get("addend")),
+            weightnorm=scalar("weightnorm"),
+            probflip=(scalar("probflip0"), scalar("probflip1")),
+            probdiff=(scalar("probdiff0"), scalar("probdiff1")),
+            lookup=lookup,
+        )
+
+    def coeff(self, feature_hash, tf):
+        """Weight of one feature occurrence set (weights.c:244-247).
+
+        The idf curve descends with index (common features weigh less), though it
+        is a fitted curve rather than a strictly monotone one -- the shipped
+        nosize table has a single 1.3e-4 wobble around index 69. That is upstream
+        data, not a parse bug.
+        """
+        idx = self.lookup.get(_as_hash(feature_hash), 0)
+        tf = int(tf)
+        if tf < 1:
+            tf = 1
+        elif tf > TF_SIZE:
+            tf = TF_SIZE
+        return self.idfweight[idx] * self.tfweight[tf - 1]
+
+    def stats(self, vector):
+        """(length, hashcount) for a ``{hash: tf}`` vector (weights.c:243-253)."""
+        length_sq = 0.0
+        hashcount = 0
+        for feature_hash, tf in vector.items():
+            c = self.coeff(feature_hash, tf)
+            length_sq += c * c
+            hashcount += int(tf)
+        return math.sqrt(length_sq), hashcount
+
+    def compare(self, vec_a, vec_b, stats_a=None, stats_b=None):
+        """Return ``(similarity, significance)`` for two ``{hash: tf}`` vectors.
+
+        Transcribes lsh_compare_internal (weights.c:404-474). Pass precomputed
+        ``stats`` to skip recomputing vector lengths.
+        """
+        len_a, hc_a = stats_a if stats_a is not None else self.stats(vec_a)
+        len_b, hc_b = stats_b if stats_b is not None else self.stats(vec_b)
+
+        # Walk the smaller vector to keep the intersection cheap.
+        if len(vec_a) > len(vec_b):
+            small, large = vec_b, vec_a
+        else:
+            small, large = vec_a, vec_b
+
+        dot = 0.0
+        intersectcount = 0
+        for feature_hash, tf_small in small.items():
+            tf_large = large.get(feature_hash)
+            if tf_large is None:
+                continue
+            t_small, t_large = int(tf_small), int(tf_large)
+            # The smaller-tf side supplies the coefficient (weights.c:428-437).
+            shared_tf = t_small if t_small < t_large else t_large
+            w = self.coeff(feature_hash, shared_tf)
+            dot += w * w
+            intersectcount += shared_tf
+
+        sim = dot / (len_a * len_b) if len_a > 0 and len_b > 0 else 0.0
+        # Identical vectors land a few ULP above 1.0; callers (min_score filters,
+        # ZSET thresholds) assume a closed [0, 1]. Ghidra does not clamp, but the
+        # correction is far below the oracle tolerance.
+        if sim > 1.0:
+            sim = 1.0
+
+        min_hc, max_hc = (hc_a, hc_b) if hc_a < hc_b else (hc_b, hc_a)
+        diff = max_hc - min_hc
+        numflip = min_hc - intersectcount
+        if max_hc > 0:
+            sig = (
+                dot
+                - numflip * (self.probflip0 + self.probflip1 / max_hc)
+                - diff * (self.probdiff0 + self.probdiff1 / max_hc)
+                + self.addend
+            )
+        else:
+            sig = self.addend
+
+        return sim, sig
+
+
+_CACHE = {}
+
+
+def load(path):
+    """Load a weights table, memoized by path. Tables are static files."""
+    key = str(path)
+    table = _CACHE.get(key)
+    if table is None:
+        table = WeightTable.from_file(path)
+        _CACHE[key] = table
+    return table
+
+
+def demo():
+    """Self-check against a synthetic table with known-by-hand values."""
+    import tempfile
+    from pathlib import Path
+
+    # scale=4 so sqrt(scale)=2 exactly; idf curve descends, tf curve ascends.
+    idf = "\n".join(f"<idf>{1.0 - i / IDF_SIZE:.8f}</idf>" for i in range(IDF_SIZE))
+    tf = "\n".join(f"<tf>{math.sqrt(i + 1):.8f}</tf>" for i in range(TF_SIZE))
+    xml = f"""<weights settings="0x4d">
+<weightfactory scale="4.0" addend="1.0">
+{idf}
+{tf}
+<weightnorm>13.0</weightnorm>
+<probflip0>0.5</probflip0><probflip1>1.0</probflip1>
+<probdiff0>0.25</probdiff0><probdiff1>2.0</probdiff1>
+</weightfactory>
+<idflookup size="2">
+<hash count="0">0xaaaa</hash>
+<hash count="511">0xbbbb</hash>
+</idflookup>
+</weights>"""
+
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "w.xml"
+        path.write_text(xml)
+        t = WeightTable.from_file(path)
+
+    # scale folding: idfweight[0] = 1.0 * sqrt(4) = 2.0
+    assert abs(t.idfweight[0] - 2.0) < 1e-12, t.idfweight[0]
+
+    # A hash absent from the lookup falls to index 0 -- the MAXIMUM weight.
+    assert t.coeff("dead", 1) == t.idfweight[0]
+    assert t.coeff("aaaa", 1) == t.idfweight[0]
+    # A common hash (high index) must weigh less than an unknown one.
+    assert t.coeff("bbbb", 1) < t.coeff("dead", 1)
+
+    # tf curve is applied at index tf-1, and clamps at TF_SIZE.
+    assert abs(t.coeff("dead", 4) - t.idfweight[0] * math.sqrt(4)) < 1e-12
+    assert t.coeff("dead", 999) == t.coeff("dead", TF_SIZE)
+
+    # Identical vectors score exactly 1.0.
+    v = {"dead": 2, "beef": 1, "bbbb": 3}
+    sim, _ = t.compare(v, v)
+    assert abs(sim - 1.0) < 1e-12, sim
+
+    # Disjoint vectors score 0.0.
+    sim, _ = t.compare({"dead": 1}, {"beef": 1})
+    assert sim == 0.0
+
+    # THE min-tf RULE: with differing tf on a shared hash, the contribution uses
+    # the smaller side's coefficient squared, NOT coeff_a * coeff_b.
+    a, b = {"dead": 1}, {"dead": 9}
+    sim, _ = t.compare(a, b)
+    w_small = t.coeff("dead", 1)
+    len_a, len_b = t.stats(a)[0], t.stats(b)[0]
+    assert abs(sim - (w_small * w_small) / (len_a * len_b)) < 1e-12
+    naive = t.coeff("dead", 1) * t.coeff("dead", 9) / (len_a * len_b)
+    assert abs(sim - naive) > 1e-9, "min-tf rule must differ from coeff_a*coeff_b"
+
+    # Similarity is invariant to `scale`; only significance moves with it.
+    # Same curves as the parsed table (matching its 8-decimal rounding), so the
+    # only difference is `scale`.
+    scaled = WeightTable(
+        idf=[float(f"{1.0 - i / IDF_SIZE:.8f}") for i in range(IDF_SIZE)],
+        tf=[float(f"{math.sqrt(i + 1):.8f}") for i in range(TF_SIZE)],
+        scale=9.0,
+        addend=1.0,
+        weightnorm=13.0,
+        probflip=(0.5, 1.0),
+        probdiff=(0.25, 2.0),
+        lookup={0xAAAA: 0, 0xBBBB: 511},
+    )
+    x, y = {"dead": 2, "beef": 1}, {"dead": 1, "cafe": 4}
+    assert abs(t.compare(x, y)[0] - scaled.compare(x, y)[0]) < 1e-12
+
+    # Significance falls as unmatched terms accumulate, even at fixed similarity.
+    sig_clean = t.compare({"dead": 1}, {"dead": 1})[1]
+    sig_noisy = t.compare({"dead": 1}, {"dead": 1, "bbbb": 20})[1]
+    assert sig_noisy < sig_clean, (sig_noisy, sig_clean)
+
+    print("bsim_weights demo OK")
+
+
+if __name__ == "__main__":
+    demo()

--- a/bsimvis/app/services/collection_config.py
+++ b/bsimvis/app/services/collection_config.py
@@ -44,3 +44,43 @@ def resolve_and_lock(collection, name, requested):
     value = requested if requested is not None else default
     get_redis().hsetnx(_META.format(coll=collection), name, value)
     return get_collection_param(collection, name, default)
+
+
+SIGNATURE_SETTINGS_FIELD = "signature_settings"
+
+
+def lock_signature_settings(collection, settings):
+    """Record the signature-settings mask on first ingest; return the locked value."""
+    get_redis().hsetnx(
+        _META.format(coll=collection), SIGNATURE_SETTINGS_FIELD, int(settings)
+    )
+    return get_collection_param(collection, SIGNATURE_SETTINGS_FIELD, int(settings))
+
+
+def get_signature_settings(collection):
+    """The mask this collection's features were extracted with, or None if unrecorded."""
+    return get_collection_param(collection, SIGNATURE_SETTINGS_FIELD, None)
+
+
+def assert_signature_settings_match(collection, settings=None):
+    """Raise ValueError if `collection` was extracted under a different mask.
+
+    `settings` defaults to the active configured mask. A collection with no
+    recorded mask is treated as compatible (legacy data, nothing to check).
+    """
+    if settings is None:
+        # imported here: bsim_profiles imports config_service, module-level would cycle
+        from bsimvis.app.services import bsim_profiles
+
+        settings = bsim_profiles.get_signature_settings()
+
+    recorded = get_signature_settings(collection)
+    if recorded is None:
+        return
+    recorded = int(recorded)
+    if recorded != int(settings):
+        raise ValueError(
+            f"Collection '{collection}' was extracted with signature settings "
+            f"{recorded:#x}, but {int(settings):#x} is active. Feature hashes from "
+            f"different masks are not comparable; re-decompile one of them to compare."
+        )

--- a/bsimvis/app/services/ghidra_service.py
+++ b/bsimvis/app/services/ghidra_service.py
@@ -12,6 +12,8 @@ import pyghidra
 from pyghidra.launcher import HeadlessPyGhidraLauncher
 import tomllib
 
+from bsimvis.app.services.bsim_profiles import get_signature_settings
+
 GHIDRA_DECOMP_MAX_TIMEOUT = 10
 DEFAULT_CONFIG_NAME = "bsimvis_config.toml"
 
@@ -463,7 +465,11 @@ class GhidraService:
         decomp_opts = DecompileOptions()
         decomp_interface = DecompInterface()
         decomp_interface.setOptions(decomp_opts)
-        decomp_interface.setSignatureSettings(0x4D)
+        # This mask changes the feature hashes themselves: changing it makes
+        # existing feature vectors incomparable and requires re-decompilation.
+        # See doc/bsim_signature_settings.md.
+        signature_settings = get_signature_settings()
+        decomp_interface.setSignatureSettings(signature_settings)
 
         if not decomp_interface.openProgram(program):
             logging.error(f"[-] Decompiler failed to initialize for {file_name}")

--- a/bsimvis/app/services/processing_service.py
+++ b/bsimvis/app/services/processing_service.py
@@ -2,6 +2,7 @@ import logging
 import json
 from bsimvis.app.services.redis_client import get_redis
 from bsimvis.app.services.index_service import save_file, save_function
+from bsimvis.app.services.collection_config import lock_signature_settings
 
 
 class ProcessingService:
@@ -229,6 +230,17 @@ class ProcessingService:
 
             base_func_key = f"{collection}:func:{file_md5}:{addr}"
             func_meta["function_id"] = base_func_key
+
+            # Lock the mask the features were extracted with, once per batch.
+            # ponytail: bookkeeping only — an unparsable decompiler_id is skipped.
+            if i == 0:
+                try:
+                    lock_signature_settings(
+                        collection,
+                        int(func_meta["decompiler_id"].rsplit(":", 1)[-1], 16),
+                    )
+                except (KeyError, AttributeError, ValueError):
+                    pass
 
             # --- Store exploded data ---
             pipe.set(f"{base_func_key}:meta", json.dumps(func_meta))

--- a/bsimvis/app/services/similarity_service.py
+++ b/bsimvis/app/services/similarity_service.py
@@ -12,6 +12,29 @@ from bsimvis.app.services.index_config import get_propagated_fields
 
 # --- Shared Lua Scripts ---
 
+# Algorithms the build path can actually compute. The candidate walk in
+# _select_candidates branches only on these; anything else falls through every
+# branch and yields unfiltered, meaningless results instead of an error.
+# `weighted_cosine` is deliberately absent: it is implemented on the exact-score
+# path only (calculate_exact_score) until the weighted pruning bounds land.
+BUILDABLE_ALGOS = ("jaccard", "unweighted_cosine", "milvus_sparse")
+
+
+def assert_buildable_algo(algo):
+    """Raise ValueError for an algorithm the build path cannot compute."""
+    if algo is None:
+        return
+    base, _ = bsim_profiles.parse_algo(algo)
+    if base in BUILDABLE_ALGOS:
+        return
+    if base == "weighted_cosine":
+        raise ValueError(
+            "weighted_cosine is not supported by the similarity build path yet "
+            "(only per-pair scoring via calculate_exact_score). Building with it "
+            "would silently produce unfiltered results. See doc/bsim_signature_settings.md."
+        )
+    raise ValueError(f"Unknown similarity algorithm {algo!r}; expected one of {BUILDABLE_ALGOS}")
+
 
 class SimilarityService:
     def __init__(self, r=None):
@@ -127,6 +150,7 @@ class SimilarityService:
         Builds similarities for all functions in a batch or for a specific file.
         Uses chunked pipelining for O(N/100) performance and throttling.
         """
+        assert_buildable_algo(algo)
         self._reset_read_caches()
         self._func_meta_cache = {}
         self._file_meta_cache = {}

--- a/bsimvis/app/services/similarity_service.py
+++ b/bsimvis/app/services/similarity_service.py
@@ -4,6 +4,8 @@ import math
 import time
 import logging
 import hashlib
+from bsimvis.app.services import bsim_profiles, bsim_weights
+from bsimvis.app.services.collection_config import assert_signature_settings_match
 from bsimvis.app.services.index_service import save_similarity
 from bsimvis.app.services.milvus_service import milvus_service
 from bsimvis.app.services.index_config import get_propagated_fields
@@ -1371,19 +1373,42 @@ class SimilarityService:
             logging.error(f"SimilarityService: Error getting pair score: {e}")
             return None
 
-    def calculate_exact_score(self, id1, id2, algo="unweighted_cosine"):
-        """Fetches feature vectors and calculates similarity directly in Python."""
+    def calculate_exact_score(self, id1, id2, algo="unweighted_cosine",
+                              with_significance=False):
+        """Fetches feature vectors and calculates similarity directly in Python.
+
+        With `with_significance`, returns `(similarity, significance)` instead of a
+        bare score. Only `weighted_cosine` defines a significance; the other algos
+        return `None` for it.
+        """
         try:
             vec1_raw = self.r.zrange(f"{id1}:vec:tf", 0, -1, withscores=True)
             vec2_raw = self.r.zrange(f"{id2}:vec:tf", 0, -1, withscores=True)
 
+            def _out(sim, sig=None):
+                return (sim, sig) if with_significance else sim
+
             if not vec1_raw or not vec2_raw:
-                return None
+                return _out(None) if with_significance else None
 
             d1 = {h: float(s) for h, s in vec1_raw}
             d2 = {h: float(s) for h, s in vec2_raw}
 
             common = set(d1.keys()).intersection(set(d2.keys()))
+
+            base_algo, profile_name = bsim_profiles.parse_algo(algo)
+            if base_algo == "weighted_cosine":
+                # Feature weights are static files, so the coefficients here never
+                # go stale as the collection grows. See doc/bsim_signature_settings.md.
+                profile = bsim_profiles.get_profile(profile_name)
+                # Vectors extracted under different masks are not comparable.
+                for fid in (id1, id2):
+                    assert_signature_settings_match(
+                        fid.split(":")[0], profile.settings
+                    )
+                table = bsim_weights.load(profile.weights_path)
+                sim, sig = table.compare(d1, d2)
+                return _out(float(sim), float(sig))
 
             if algo == "jaccard":
                 # Generalized Jaccard (Tanimoto): sum(min(a,b)) / sum(max(a,b))

--- a/bsimvis/app/services/similarity_service.py
+++ b/bsimvis/app/services/similarity_service.py
@@ -1405,15 +1405,15 @@ class SimilarityService:
         bare score. Only `weighted_cosine` defines a significance; the other algos
         return `None` for it.
         """
+        def _out(sim, sig=None):
+            return (sim, sig) if with_significance else sim
+
         try:
             vec1_raw = self.r.zrange(f"{id1}:vec:tf", 0, -1, withscores=True)
             vec2_raw = self.r.zrange(f"{id2}:vec:tf", 0, -1, withscores=True)
 
-            def _out(sim, sig=None):
-                return (sim, sig) if with_significance else sim
-
             if not vec1_raw or not vec2_raw:
-                return _out(None) if with_significance else None
+                return _out(None)
 
             d1 = {h: float(s) for h, s in vec1_raw}
             d2 = {h: float(s) for h, s in vec2_raw}
@@ -1465,12 +1465,18 @@ class SimilarityService:
                     else 0.0
                 )
 
-            return None
+            return _out(None)
+        except ValueError:
+            # Misconfiguration, not a missing score: an unknown profile, a weights
+            # table that disagrees with the mask, or a collection extracted under
+            # different signature settings. Callers must be able to tell the user
+            # what is wrong rather than see a silent None.
+            raise
         except Exception as e:
             logging.error(
                 f"SimilarityService: Error calculating exact score for {id1}, {id2}: {e}"
             )
-            return None
+            return _out(None)
 
     def check_cache(self, id1, id2, collection, algo):
         """Checks if a similarity pair is already built."""

--- a/bsimvis/cli/bsimvis_sim.py
+++ b/bsimvis/cli/bsimvis_sim.py
@@ -106,6 +106,35 @@ def run_sim(host, port, args):
         except Exception as e:
             print(f"[!] Error listing similarity scores: {e}")
 
+    elif args.action == "score":
+        params = {"id1": args.id1, "id2": args.id2, "algo": args.algo}
+        if coll:
+            params["collection"] = coll
+        try:
+            resp = requests.get(api_url, params=params)
+            data = resp.json()
+            if resp.status_code != 200:
+                print(f"[!] {data.get('detail') or data}")
+                return
+            scores = data.get("scores", {})
+            sigs = data.get("significance", {})
+            errors = data.get("errors", {})
+            print(f"[*] {data.get('id1')}")
+            print(f"    {data.get('id2')}   (source: {data.get('source')})")
+            for algo in [a.strip() for a in args.algo.split(",") if a.strip()]:
+                if algo in errors:
+                    print(f"  {algo:24s} ERROR: {errors[algo]}")
+                    continue
+                score = scores.get(algo)
+                line = f"  {algo:24s} {score:.6f}" if score is not None else f"  {algo:24s} n/a"
+                if algo in sigs:
+                    # Significance is unbounded: it scales with the total weight
+                    # matched, so a high score on trivial features stays low here.
+                    line += f"   significance={sigs[algo]:.4f}"
+                print(line)
+        except Exception as e:
+            print(f"[!] Error scoring pair: {e}")
+
     elif args.action == "build":
         targets = []
         if args.md5:

--- a/bsimvis/cli/main.py
+++ b/bsimvis/cli/main.py
@@ -331,6 +331,22 @@ def main():
     bs_diff.add_argument("--md5-b", required=True, help="Second binary MD5")
 
     # sim list
+    # Pair scoring is separate from the build actions on purpose: it can run
+    # algorithms the build path cannot compute (weighted_cosine), so it must not
+    # share their --algo choices.
+    sim_score = sim_actions.add_parser(
+        "score", help="Score one function pair on demand (supports weighted_cosine)"
+    )
+    sim_score.add_argument("-c", "--collection", help="Collection name")
+    sim_score.add_argument("--id1", required=True, help="First function ID")
+    sim_score.add_argument("--id2", required=True, help="Second function ID")
+    sim_score.add_argument(
+        "--algo",
+        default="jaccard,unweighted_cosine,weighted_cosine",
+        help="Comma-separated algorithms. weighted_cosine may be profile-qualified "
+        "(weighted_cosine:nosize) and also reports significance.",
+    )
+
     sim_list = sim_actions.add_parser("list", help="List similarity builds")
     sim_list.add_argument("-c", "--collection", required=True, help="Collection name")
     sim_list.add_argument("--batch", help="Target specific batch UUID")

--- a/bsimvis_config.toml.example
+++ b/bsimvis_config.toml.example
@@ -43,6 +43,37 @@
     # filters. Slowest phase of a clustering run; set false to skip it.
     propagate_sim_indexes = true
 
+[bsim]
+    # Which signature/weights profile to use. See doc/bsim_signature_settings.md.
+    #
+    # `settings` is the Ghidra decompiler signature-settings mask. It controls how
+    # feature hashes are generated, so CHANGING IT REQUIRES FULL RE-DECOMPILATION
+    # of a collection -- existing feature vectors become incomparable.
+    #
+    # `weights` is the BSim weight table paired with that mask. The mask alone does
+    # not identify a table (four of Ghidra's five declare 0x49), so the pairing is
+    # explicit here. A bare filename resolves against Ghidra's BSim data dir; a path
+    # with a separator is treated as repo-relative, for custom tables.
+    profile = "nosize"
+
+    [bsim.profiles.nosize]
+        # 0x4D = SIG_COLLAPSE_SIZE | SIG_COLLAPSE_INDNOISE | SIG_DONOTUSE_CONST
+        settings = 0x4D
+        weights = "lshweights_nosize.xml"
+    [bsim.profiles.sized_32]
+        # 0x49 = nosize minus SIG_COLLAPSE_SIZE
+        settings = 0x49
+        weights = "lshweights_32.xml"
+    [bsim.profiles.sized_64]
+        settings = 0x49
+        weights = "lshweights_64.xml"
+    [bsim.profiles.sized_64_32]
+        settings = 0x49
+        weights = "lshweights_64_32.xml"
+    [bsim.profiles.cpool]
+        settings = 0x49
+        weights = "lshweights_cpool.xml"
+
 [similarity]
     top_k = 1000
     min_score = 0.9

--- a/doc/bsim_signature_settings.md
+++ b/doc/bsim_signature_settings.md
@@ -1,0 +1,58 @@
+# BSim Signature Settings
+
+`DecompInterface.setSignatureSettings(mask)` controls how the Ghidra decompiler generates BSim feature hashes for a function. BSimVis sets it in `bsimvis/app/services/ghidra_service.py`.
+
+## 1. Mask Layout
+
+Bit 0 is a check bit; the modifier flags start at bit 2. The decompiler computes `sigmods = setting >> 2` (Ghidra `Ghidra/Features/Decompiler/src/decompile/cpp/signature.cc:933`). A value of `0` is rejected.
+
+Note that `GraphSigManager::testSettings` only *permits* bit 0 — it does not require it. Validation is exactly "non-zero, and no bit set outside the allowed mask", so `0x4C` (`0x4D` without the check bit) also passes. Ghidra's own configurations always set it.
+
+`GraphSigManager::testSettings` (`signature.cc:914-924`) permits only:
+
+```
+((SIG_COLLAPSE_SIZE | SIG_COLLAPSE_INDNOISE | SIG_DONOTUSE_CONST |
+  SIG_DONOTUSE_INPUT | SIG_DONOTUSE_PERSIST) << 2) | 1   ==   0x1CD
+```
+
+Any bit outside that set is an error.
+
+## 2. Flags
+
+Source: `signature.hh:269-274`.
+
+| Flag | Value | Meaning |
+| --- | --- | --- |
+| `SIG_COLLAPSE_SIZE` | `0x1` | Treat certain varnode sizes as the same |
+| `SIG_COLLAPSE_INDNOISE` | `0x2` | Collapse varnodes that are indirect copies of each other |
+| `SIG_DONOTUSE_CONST` | `0x10` | Do not use the value of a constant in the hash |
+| `SIG_DONOTUSE_INPUT` | `0x20` | Do not use (fact of) being an input in the hash |
+| `SIG_DONOTUSE_PERSIST` | `0x40` | Do not use (fact of) being a global in the hash |
+
+## 3. Decoding `0x4D`
+
+`0x4D` is the value BSimVis uses. In binary, `0b1001101`: the check bit is set, and `sigmods = 0x4D >> 2 = 0x13`, that is
+
+```
+SIG_COLLAPSE_SIZE | SIG_COLLAPSE_INDNOISE | SIG_DONOTUSE_CONST
+```
+
+This is the "nosize" configuration: varnode sizes are collapsed, so 32-bit and 64-bit builds of the same source can match. Contrast `0x49`, the same set minus `SIG_COLLAPSE_SIZE` — the "sized" configuration.
+
+## 4. Constants Never Enter the Hash
+
+`SIG_DONOTUSE_CONST` is set in every Ghidra BSim configuration, so constant *values* never contribute to feature hashes. Two builds that differ only in embedded constant data — an encrypted config blob, for example — produce identical signatures.
+
+## 5. Lifecycle Warning
+
+This mask changes the feature hashes *themselves*, at extraction time. Changing it invalidates every stored feature vector and requires a full re-decompilation of the collection.
+
+This is the opposite of feature *weights*, which only re-interpret hashes that already exist. Weights can be swapped freely with no re-ingest.
+
+## 6. Weights Tables
+
+Ghidra ships weight tables in `Ghidra/Features/BSim/data/lshweights_*.xml`. Each declares the settings mask it belongs to via `<weights settings="0x...">`, and a table must only be used with the matching mask.
+
+The mask alone does not identify a file: `lshweights_32.xml`, `lshweights_64.xml`, `lshweights_64_32.xml` and `lshweights_cpool.xml` all declare `0x49`, while only `lshweights_nosize.xml` declares `0x4d`. Ghidra resolves the pairing through database template configs such as `data/medium_nosize.xml`, which holds `<settings>0x4d</settings>`, `<k>17</k>`, `<L>146</L>` and `<weightsfile>lshweights_nosize.xml</weightsfile>`.
+
+BSimVis therefore makes the mask/weights pairing explicit in configuration rather than inferring it from the mask.

--- a/scripts/bench/idf_coverage.py
+++ b/scripts/bench/idf_coverage.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Go/no-go gate for BSim feature weighting (MISP/bsimvis#30).
+
+Ghidra's IDF table lists the 1000 most common feature hashes in *its* training
+corpus, which is predominantly x86 C/C++. This collection is heavily Go on
+MIPS/ARM/SH4/m68k. A hash absent from that table resolves to lookup index 0,
+which carries the *largest* weight -- so if our boilerplate is missing from
+Ghidra's list, weighting would amplify exactly the features it is meant to
+suppress.
+
+This measures that before any scorer is written. It reads only keys that already
+exist -- per-feature document frequency is materialized as
+`{coll}:feature:{hash}:functions` -- so it is a read loop, not a corpus scan.
+
+Usage:
+    scripts/bench/idf_coverage.py <collection> [--top 50] [--profile nosize]
+"""
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from bsimvis.app.services import bsim_profiles, bsim_weights  # noqa: E402
+from bsimvis.app.services.redis_client import get_redis  # noqa: E402
+
+
+def collect_document_frequencies(r, collection):
+    """{hash_int: document_frequency} from the materialized posting lists."""
+    dfs = {}
+    pattern = f"{collection}:feature:*:functions"
+    batch = []
+
+    def flush(keys):
+        if not keys:
+            return
+        pipe = r.pipeline(transaction=False)
+        for k in keys:
+            pipe.zcard(k)
+        for k, count in zip(keys, pipe.execute()):
+            name = k.decode() if isinstance(k, bytes) else k
+            # {coll}:feature:{hash}:functions
+            f_hash = name.split(":")[-2]
+            try:
+                dfs[int(f_hash, 16)] = count
+            except ValueError:
+                continue
+
+    for key in r.scan_iter(match=pattern, count=1000):
+        batch.append(key)
+        if len(batch) >= 1000:
+            flush(batch)
+            batch = []
+    flush(batch)
+    return dfs
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("collection")
+    ap.add_argument("--top", type=int, default=50, help="how many high-DF hashes to list")
+    ap.add_argument("--profile", default=None, help="BSim profile (default: configured)")
+    args = ap.parse_args()
+
+    profile = bsim_profiles.get_profile(args.profile)
+    table = bsim_weights.load(profile.weights_path)
+    print(f"profile        : {profile.name} (settings {profile.settings:#x})")
+    print(f"weights table  : {profile.weights_path}")
+    print(f"idflookup size : {len(table.lookup)}")
+
+    r = get_redis()
+    dfs = collect_document_frequencies(r, args.collection)
+    if not dfs:
+        print(f"\nNo features found for collection {args.collection!r}.")
+        return 1
+
+    total_hashes = len(dfs)
+    total_occurrences = sum(dfs.values())
+    covered = {h: df for h, df in dfs.items() if h in table.lookup}
+    covered_occurrences = sum(covered.values())
+
+    print(f"\ncollection     : {args.collection}")
+    print(f"distinct hashes: {total_hashes}")
+    print(f"total feature occurrences (sum of DF): {total_occurrences}")
+
+    print("\n--- Coverage by Ghidra's idflookup ---")
+    print(
+        f"distinct hashes covered   : {len(covered)}/{total_hashes} "
+        f"({100.0 * len(covered) / total_hashes:.2f}%)"
+    )
+    # This is the number that matters: a table can cover few distinct hashes and
+    # still cover most of what actually occurs, or the reverse.
+    print(
+        f"OCCURRENCES covered       : {covered_occurrences}/{total_occurrences} "
+        f"({100.0 * covered_occurrences / total_occurrences:.2f}%)"
+    )
+
+    max_weight = table.idfweight[0]
+    print(f"\n--- Top {args.top} highest-DF hashes here ---")
+    print(f"{'hash':>10}  {'DF':>8}  {'idx':>4}  {'weight':>8}  {'w/max':>6}  status")
+    ranked = sorted(dfs.items(), key=lambda kv: kv[1], reverse=True)[: args.top]
+    unknown_in_top = 0
+    for h, df in ranked:
+        idx = table.lookup.get(h)
+        if idx is None:
+            idx_s, status = "-", "ABSENT -> MAX WEIGHT"
+            weight = max_weight
+            unknown_in_top += 1
+        else:
+            idx_s, status = str(idx), "known"
+            weight = table.idfweight[idx]
+        print(
+            f"0x{h:08x}  {df:8d}  {idx_s:>4}  {weight:8.4f}  "
+            f"{weight / max_weight:6.3f}  {status}"
+        )
+
+    print(
+        f"\n{unknown_in_top}/{len(ranked)} of this collection's most common features are "
+        f"ABSENT from Ghidra's table"
+    )
+    print("and would therefore receive the maximum weight.")
+    print(
+        "\nVerdict: the higher that count and the lower the occurrence coverage, the more "
+        "\nGhidra's shipped table misreads this corpus. If most top-DF features are absent, "
+        "\nadopt a table derived from an independent reference pool instead "
+        "(scripts/bench/make_weights.py) rather than the shipped one."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench/oracle_compare.py
+++ b/scripts/bench/oracle_compare.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Oracle test: our BSim weighting math vs Ghidra's own WeightedLSHCosineVectorFactory.
+
+Mirrors CompareBSimSignaturesScript.java: build the same weighted vector factory
+from lshweights_nosize.xml, build LSHVectors for real functions, and check
+Ghidra's (similarity, significance) against bsim_weights.WeightTable.compare().
+
+Usage:
+    GHIDRA_INSTALL_DIR=... .venv/bin/python scripts/bench/oracle_compare.py [binary]
+"""
+
+import argparse
+import itertools
+import os
+import random
+import sys
+from collections import Counter
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+DEFAULT_BINARY = "/home/thomas/data/versioned_c/bin/v01_linux_x64"
+SIM_TOL = 1e-9
+SIG_TOL = 1e-6
+MIN_FEATURES = 10
+COLLISION_SIM = 0.95
+
+
+def build_factory(weights_path):
+    """WeightedLSHCosineVectorFactory loaded from a weights XML (readWeights, ~line 152)."""
+    from generic.lsh.vector import WeightedLSHCosineVectorFactory
+    from ghidra.util.xml import SpecXmlUtils
+    from ghidra.xml import NonThreadedXmlPullParserImpl
+    from java.io import FileInputStream
+
+    factory = WeightedLSHCosineVectorFactory()
+    stream = FileInputStream(str(weights_path))
+    try:
+        parser = NonThreadedXmlPullParserImpl(
+            stream, "Vector weights parser", SpecXmlUtils.getXmlHandler(), False
+        )
+        factory.readWeights(parser)
+    finally:
+        stream.close()
+    return factory
+
+
+def our_vector(decomp, func, monitor):
+    """{hash: tf} exactly as ghidra_service.py extracts it."""
+    sigs = decomp.debugSignatures(func, 10, monitor)
+    if not sigs:
+        return {}
+    return dict(Counter(hex(sigs.get(i).hash & 0xFFFFFFFF)[2:] for i in range(sigs.size())))
+
+
+def ghidra_vector_entries(vec):
+    """{hash: tf} read back out of Ghidra's own LSHVector."""
+    entries = vec.getEntries()
+    out = {}
+    for e in entries:
+        out[hex(e.getHash() & 0xFFFFFFFF)[2:]] = int(e.getTF())
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("binary", nargs="?", default=DEFAULT_BINARY)
+    ap.add_argument("--weights", default=None, help="lshweights_*.xml (default: nosize)")
+    ap.add_argument("--pairs", type=int, default=60)
+    args = ap.parse_args()
+
+    ghidra_dir = os.environ.get("GHIDRA_INSTALL_DIR")
+    if not ghidra_dir:
+        sys.exit("GHIDRA_INSTALL_DIR is not set")
+    weights_path = args.weights or os.path.join(
+        ghidra_dir, "Ghidra/Features/BSim/data/lshweights_nosize.xml"
+    )
+
+    # Import before the JVM starts: jpype's import hook shadows dotted names.
+    from bsimvis.app.services import bsim_weights
+
+    import pyghidra
+    from pyghidra.launcher import HeadlessPyGhidraLauncher
+
+    HeadlessPyGhidraLauncher(verbose=False).start()
+
+    table = bsim_weights.WeightTable.from_file(weights_path)
+
+    from ghidra.app.decompiler import DecompInterface, DecompileOptions
+    from generic.lsh.vector import VectorCompare
+    from ghidra.util.task import ConsoleTaskMonitor
+
+    factory = build_factory(weights_path)
+    settings = factory.getSettings()
+    print(f"vectorFactory.getSettings() = 0x{settings:X}")
+    assert settings == 0x4D, f"expected 0x4D, got 0x{settings:X}"
+
+    monitor = ConsoleTaskMonitor()
+    failures = []
+
+    with pyghidra.open_program(args.binary, analyze=True) as flat:
+        program = flat.getCurrentProgram()
+        decomp = DecompInterface()
+        decomp.setOptions(DecompileOptions())
+        decomp.toggleSyntaxTree(False)
+        decomp.setSignatureSettings(settings)
+        if not decomp.openProgram(program):
+            sys.exit(f"decompiler: {decomp.getLastMessage()}")
+
+        funcs = []
+        for func in program.getFunctionManager().getFunctions(True):
+            if func.isExternal() or func.isThunk():
+                continue
+            name = func.getName()
+            if name.startswith("FUN_"):
+                continue
+            sigres = decomp.generateSignatures(func, False, 10, monitor)
+            if sigres is None or sigres.features is None or len(sigres.features) < MIN_FEATURES:
+                continue
+            gvec = factory.buildVector(sigres.features)
+            ours = our_vector(decomp, func, monitor)
+            if not ours:
+                continue
+            funcs.append((name, gvec, ours))
+
+        print(f"functions processed: {len(funcs)}")
+
+        # Cross-check: our dict vs the contents of Ghidra's own LSHVector.
+        mismatched = []
+        for name, gvec, ours in funcs:
+            theirs = ghidra_vector_entries(gvec)
+            if theirs != ours:
+                only_ours = {k: v for k, v in ours.items() if theirs.get(k) != v}
+                only_theirs = {k: v for k, v in theirs.items() if ours.get(k) != v}
+                mismatched.append((name, len(ours), len(theirs), only_ours, only_theirs))
+        if mismatched:
+            print(f"VECTOR MISMATCH in {len(mismatched)}/{len(funcs)} functions:")
+            for name, n_ours, n_theirs, only_ours, only_theirs in mismatched[:5]:
+                print(f"  {name}: ours={n_ours} entries, ghidra={n_theirs} entries")
+                print(f"    ours-differing (first 5): {dict(itertools.islice(only_ours.items(), 5))}")
+                print(f"    ghidra-differing (first 5): {dict(itertools.islice(only_theirs.items(), 5))}")
+            failures.append("vector contents disagree")
+        else:
+            print(f"vectors match: yes ({len(funcs)}/{len(funcs)} functions, hash+tf identical)")
+
+        # Pairs: self-pairs first (identical), then all cross pairs.
+        pairs = [(i, i) for i in range(len(funcs))]
+        cross = list(itertools.combinations(range(len(funcs)), 2))
+        random.Random(0).shuffle(cross)  # spread across the function set, not just func 0
+        pairs += cross
+        pairs = pairs[: max(args.pairs, len(funcs))]
+
+        results = []
+        for i, j in pairs:
+            name_a, gvec_a, ours_a = funcs[i]
+            name_b, gvec_b, ours_b = funcs[j]
+            vc = VectorCompare()
+            g_sim = gvec_a.compare(gvec_b, vc)
+            g_sig = factory.calculateSignificance(vc)
+            o_sim, o_sig = table.compare(ours_a, ours_b)
+            results.append(
+                (abs(g_sim - o_sim), abs(g_sig - o_sig), name_a, name_b, g_sim, o_sim, g_sig, o_sig)
+            )
+
+        # Distinct source functions that share a feature vector are indistinguishable
+        # to ANY weighting scheme -- an information limit of the signature, not an
+        # algorithm error. Measuring this ceiling first keeps it from being counted
+        # as a false positive later.
+        identical = []
+        near = []
+        for i, j in itertools.combinations(range(len(funcs)), 2):
+            name_a, gvec_a, ours_a = funcs[i]
+            name_b, _, ours_b = funcs[j]
+            if ours_a == ours_b:
+                identical.append((name_a, name_b))
+            else:
+                sim, _ = table.compare(ours_a, ours_b)
+                if sim >= COLLISION_SIM:
+                    near.append((sim, name_a, name_b))
+        n_cross = len(funcs) * (len(funcs) - 1) // 2
+        print(
+            f"\nceiling: {len(identical)}/{n_cross} distinct-function pairs have "
+            f"IDENTICAL feature vectors"
+        )
+        for a, b in identical[:10]:
+            print(f"  identical: {a} <-> {b}")
+        print(
+            f"ceiling: {len(near)}/{n_cross} further pairs score >= {COLLISION_SIM} "
+            f"without being identical"
+        )
+        for sim, a, b in sorted(near, reverse=True)[:10]:
+            print(f"  {sim:.4f}: {a} <-> {b}")
+
+        decomp.closeProgram()
+        decomp.dispose()
+
+    print(f"pairs compared: {len(results)}")
+    max_sim = max(r[0] for r in results)
+    max_sig = max(r[1] for r in results)
+    print(f"max |sim diff| = {max_sim:.3e}   (tol {SIM_TOL:.0e})")
+    print(f"max |sig diff| = {max_sig:.3e}   (tol {SIG_TOL:.0e})")
+
+    print("worst 5 pairs by similarity difference:")
+    for d_sim, d_sig, a, b, gs, os_, gg, og in sorted(results, reverse=True)[:5]:
+        print(f"  {a} vs {b}: dsim={d_sim:.3e} ghidra={gs!r} ours={os_!r}")
+        print(f"      dsig={d_sig:.3e} ghidra={gg!r} ours={og!r}")
+
+    print("worst 5 pairs by significance difference:")
+    for d_sim, d_sig, a, b, gs, os_, gg, og in sorted(results, key=lambda r: -r[1])[:5]:
+        print(f"  {a} vs {b}: dsig={d_sig:.3e} ghidra={gg!r} ours={og!r} (sim {gs!r}/{os_!r})")
+
+    if max_sim > SIM_TOL:
+        failures.append(f"similarity diff {max_sim:.3e} > {SIM_TOL:.0e}")
+    if max_sig > SIG_TOL:
+        failures.append(f"significance diff {max_sig:.3e} > {SIG_TOL:.0e}")
+
+    if failures:
+        print("ORACLE FAILED: " + "; ".join(failures))
+        return 1
+    print("ORACLE PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench/oracle_compare.py
+++ b/scripts/bench/oracle_compare.py
@@ -195,6 +195,10 @@ def main():
     ap.add_argument("--binary-b", default=None, help="second binary: compare full A x B")
     ap.add_argument("--weights", default=None, help="lshweights_*.xml (default: nosize)")
     ap.add_argument("--pairs", type=int, default=60)
+    ap.add_argument(
+        "--dump-vectors", default=None,
+        help="write the extracted {name: {hash: tf}} vectors to JSON (for offline benchmarks)",
+    )
     args = ap.parse_args()
 
     ghidra_dir = os.environ.get("GHIDRA_INSTALL_DIR")
@@ -234,6 +238,16 @@ def main():
         print(f"functions processed [B {os.path.basename(args.binary_b)}]: {len(funcs_b)}")
 
     # Also proves the LSHVectors survived their program being closed.
+    if args.dump_vectors:
+        import json
+
+        dump = {"A": {name: ours for name, _, ours in funcs}}
+        if funcs_b:
+            dump["B"] = {name: ours for name, _, ours in funcs_b}
+        with open(args.dump_vectors, "w") as fh:
+            json.dump(dump, fh)
+        print(f"wrote vectors to {args.dump_vectors}")
+
     check_vectors("A", funcs, failures)
     if funcs_b is not None:
         check_vectors("B", funcs_b, failures)

--- a/scripts/bench/oracle_compare.py
+++ b/scripts/bench/oracle_compare.py
@@ -61,9 +61,138 @@ def ghidra_vector_entries(vec):
     return out
 
 
+def extract(binary, factory, settings, monitor):
+    """Open `binary`, return [(name, ghidra LSHVector, our {hash: tf})]."""
+    import pyghidra
+    from ghidra.app.decompiler import DecompInterface, DecompileOptions
+
+    funcs = []
+    with pyghidra.open_program(binary, analyze=True) as flat:
+        program = flat.getCurrentProgram()
+        decomp = DecompInterface()
+        decomp.setOptions(DecompileOptions())
+        decomp.toggleSyntaxTree(False)
+        decomp.setSignatureSettings(settings)
+        if not decomp.openProgram(program):
+            sys.exit(f"decompiler: {decomp.getLastMessage()}")
+
+        for func in program.getFunctionManager().getFunctions(True):
+            if func.isExternal() or func.isThunk():
+                continue
+            name = func.getName()
+            if name.startswith("FUN_"):
+                continue
+            sigres = decomp.generateSignatures(func, False, 10, monitor)
+            if sigres is None or sigres.features is None or len(sigres.features) < MIN_FEATURES:
+                continue
+            gvec = factory.buildVector(sigres.features)
+            ours = our_vector(decomp, func, monitor)
+            if not ours:
+                continue
+            funcs.append((name, gvec, ours))
+
+        decomp.closeProgram()
+        decomp.dispose()
+    return funcs
+
+
+def check_vectors(label, funcs, failures):
+    """Our dict vs the contents of Ghidra's own LSHVector (also proves the
+    LSHVectors are still readable after their program context closed)."""
+    mismatched = []
+    for name, gvec, ours in funcs:
+        theirs = ghidra_vector_entries(gvec)
+        if theirs != ours:
+            only_ours = {k: v for k, v in ours.items() if theirs.get(k) != v}
+            only_theirs = {k: v for k, v in theirs.items() if ours.get(k) != v}
+            mismatched.append((name, len(ours), len(theirs), only_ours, only_theirs))
+    if mismatched:
+        print(f"[{label}] VECTOR MISMATCH in {len(mismatched)}/{len(funcs)} functions:")
+        for name, n_ours, n_theirs, only_ours, only_theirs in mismatched[:5]:
+            print(f"  {name}: ours={n_ours} entries, ghidra={n_theirs} entries")
+            print(f"    ours-differing (first 5): {dict(itertools.islice(only_ours.items(), 5))}")
+            print(f"    ghidra-differing (first 5): {dict(itertools.islice(only_theirs.items(), 5))}")
+        failures.append(f"[{label}] vector contents disagree")
+    else:
+        print(f"[{label}] vectors match: yes ({len(funcs)}/{len(funcs)}, hash+tf identical)")
+
+
+def print_buckets(results):
+    """Bucketed agreement table, keyed on Ghidra's similarity."""
+    edges = [(i / 10, (i + 1) / 10) for i in range(10)]
+    print("\nbucketed agreement (bucket by Ghidra similarity):")
+    print(f"  {'bucket':>12} {'pairs':>8} {'max|dsim|':>12} {'max|dsig|':>12}")
+    rows = [(f"[{lo:.1f},{hi:.1f})", lambda s, lo=lo, hi=hi: lo <= s < hi) for lo, hi in edges]
+    rows.append(("== 1.0", lambda s: s >= 1.0))
+    for label, pred in rows:
+        sel = [r for r in results if pred(r[4])]
+        if not sel:
+            print(f"  {label:>12} {0:>8}            -            -")
+            continue
+        print(
+            f"  {label:>12} {len(sel):>8} {max(r[0] for r in sel):>12.3e} "
+            f"{max(r[1] for r in sel):>12.3e}"
+        )
+
+
+def print_name_summary(results):
+    """Descriptive only: same-name (true cross-arch matches) vs different-name."""
+    import statistics
+
+    same = sorted(r[4] for r in results if r[2] == r[3])
+    diff = [r for r in results if r[2] != r[3]]
+    print("\ncross-binary name summary (descriptive, not part of the verdict):")
+    if same:
+        print(
+            f"  SAME-NAME pairs: n={len(same)} min={same[0]:.4f} "
+            f"median={statistics.median(same):.4f} max={same[-1]:.4f}"
+        )
+    else:
+        print("  SAME-NAME pairs: none")
+    if diff:
+        sims = sorted(r[4] for r in diff)
+        print(
+            f"  DIFF-NAME pairs: n={len(diff)} median={statistics.median(sims):.4f} "
+            f"max={sims[-1]:.4f}"
+        )
+        print("  top 10 different-name scorers (sim / significance):")
+        for r in sorted(diff, key=lambda r: -r[4])[:10]:
+            print(f"    sim={r[4]:.4f} sig={r[6]:8.3f}  {r[2]}  <->  {r[3]}")
+        # Does significance separate what similarity cannot? Compare the weakest
+        # true match against the strongest false one -- if the false pair scores
+        # higher on similarity but lower on significance, significance is the
+        # discriminator the threshold cannot be.
+        same_pairs = [r for r in results if r[2] == r[3]]
+        if same_pairs:
+            worst_true = min(same_pairs, key=lambda r: r[4])
+            best_false = max(diff, key=lambda r: r[4])
+            print("\n  discrimination check:")
+            print(
+                f"    weakest TRUE  match: sim={worst_true[4]:.4f} "
+                f"sig={worst_true[6]:8.3f}  {worst_true[2]}"
+            )
+            print(
+                f"    strongest FALSE pair: sim={best_false[4]:.4f} "
+                f"sig={best_false[6]:8.3f}  {best_false[2]} <-> {best_false[3]}"
+            )
+            sims = [r[4] for r in same_pairs]
+            sigs = [r[6] for r in same_pairs]
+            print(
+                f"    TRUE  sim range [{min(sims):.4f}, {max(sims):.4f}]  "
+                f"sig range [{min(sigs):.3f}, {max(sigs):.3f}]"
+            )
+            dsims = [r[4] for r in diff]
+            dsigs = [r[6] for r in diff]
+            print(
+                f"    FALSE sim range [{min(dsims):.4f}, {max(dsims):.4f}]  "
+                f"sig range [{min(dsigs):.3f}, {max(dsigs):.3f}]"
+            )
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("binary", nargs="?", default=DEFAULT_BINARY)
+    ap.add_argument("--binary-b", default=None, help="second binary: compare full A x B")
     ap.add_argument("--weights", default=None, help="lshweights_*.xml (default: nosize)")
     ap.add_argument("--pairs", type=int, default=60)
     args = ap.parse_args()
@@ -97,103 +226,81 @@ def main():
     monitor = ConsoleTaskMonitor()
     failures = []
 
-    with pyghidra.open_program(args.binary, analyze=True) as flat:
-        program = flat.getCurrentProgram()
-        decomp = DecompInterface()
-        decomp.setOptions(DecompileOptions())
-        decomp.toggleSyntaxTree(False)
-        decomp.setSignatureSettings(settings)
-        if not decomp.openProgram(program):
-            sys.exit(f"decompiler: {decomp.getLastMessage()}")
+    funcs = extract(args.binary, factory, settings, monitor)
+    print(f"functions processed [A {os.path.basename(args.binary)}]: {len(funcs)}")
+    funcs_b = None
+    if args.binary_b:
+        funcs_b = extract(args.binary_b, factory, settings, monitor)
+        print(f"functions processed [B {os.path.basename(args.binary_b)}]: {len(funcs_b)}")
 
-        funcs = []
-        for func in program.getFunctionManager().getFunctions(True):
-            if func.isExternal() or func.isThunk():
-                continue
-            name = func.getName()
-            if name.startswith("FUN_"):
-                continue
-            sigres = decomp.generateSignatures(func, False, 10, monitor)
-            if sigres is None or sigres.features is None or len(sigres.features) < MIN_FEATURES:
-                continue
-            gvec = factory.buildVector(sigres.features)
-            ours = our_vector(decomp, func, monitor)
-            if not ours:
-                continue
-            funcs.append((name, gvec, ours))
+    # Also proves the LSHVectors survived their program being closed.
+    check_vectors("A", funcs, failures)
+    if funcs_b is not None:
+        check_vectors("B", funcs_b, failures)
 
-        print(f"functions processed: {len(funcs)}")
-
-        # Cross-check: our dict vs the contents of Ghidra's own LSHVector.
-        mismatched = []
-        for name, gvec, ours in funcs:
-            theirs = ghidra_vector_entries(gvec)
-            if theirs != ours:
-                only_ours = {k: v for k, v in ours.items() if theirs.get(k) != v}
-                only_theirs = {k: v for k, v in theirs.items() if ours.get(k) != v}
-                mismatched.append((name, len(ours), len(theirs), only_ours, only_theirs))
-        if mismatched:
-            print(f"VECTOR MISMATCH in {len(mismatched)}/{len(funcs)} functions:")
-            for name, n_ours, n_theirs, only_ours, only_theirs in mismatched[:5]:
-                print(f"  {name}: ours={n_ours} entries, ghidra={n_theirs} entries")
-                print(f"    ours-differing (first 5): {dict(itertools.islice(only_ours.items(), 5))}")
-                print(f"    ghidra-differing (first 5): {dict(itertools.islice(only_theirs.items(), 5))}")
-            failures.append("vector contents disagree")
-        else:
-            print(f"vectors match: yes ({len(funcs)}/{len(funcs)} functions, hash+tf identical)")
-
-        # Pairs: self-pairs first (identical), then all cross pairs.
-        pairs = [(i, i) for i in range(len(funcs))]
-        cross = list(itertools.combinations(range(len(funcs)), 2))
-        random.Random(0).shuffle(cross)  # spread across the function set, not just func 0
-        pairs += cross
-        pairs = pairs[: max(args.pairs, len(funcs))]
-
-        results = []
-        for i, j in pairs:
-            name_a, gvec_a, ours_a = funcs[i]
-            name_b, gvec_b, ours_b = funcs[j]
+    def compare_pairs(pairs):
+        out = []
+        for (name_a, gvec_a, ours_a), (name_b, gvec_b, ours_b) in pairs:
             vc = VectorCompare()
             g_sim = gvec_a.compare(gvec_b, vc)
             g_sig = factory.calculateSignificance(vc)
             o_sim, o_sig = table.compare(ours_a, ours_b)
-            results.append(
+            out.append(
                 (abs(g_sim - o_sim), abs(g_sig - o_sig), name_a, name_b, g_sim, o_sim, g_sig, o_sig)
             )
+        return out
 
-        # Distinct source functions that share a feature vector are indistinguishable
-        # to ANY weighting scheme -- an information limit of the signature, not an
-        # algorithm error. Measuring this ceiling first keeps it from being counted
-        # as a false positive later.
-        identical = []
-        near = []
-        for i, j in itertools.combinations(range(len(funcs)), 2):
-            name_a, gvec_a, ours_a = funcs[i]
-            name_b, _, ours_b = funcs[j]
-            if ours_a == ours_b:
-                identical.append((name_a, name_b))
-            else:
-                sim, _ = table.compare(ours_a, ours_b)
-                if sim >= COLLISION_SIM:
-                    near.append((sim, name_a, name_b))
-        n_cross = len(funcs) * (len(funcs) - 1) // 2
-        print(
-            f"\nceiling: {len(identical)}/{n_cross} distinct-function pairs have "
-            f"IDENTICAL feature vectors"
+    if funcs_b is None:
+        # Pairs: self-pairs first (identical), then all cross pairs.
+        idx = [(i, i) for i in range(len(funcs))]
+        cross = list(itertools.combinations(range(len(funcs)), 2))
+        random.Random(0).shuffle(cross)  # spread across the function set, not just func 0
+        idx += cross
+        idx = idx[: max(args.pairs, len(funcs))]
+        results = compare_pairs([(funcs[i], funcs[j]) for i, j in idx])
+        cross_results = None
+    else:
+        cross_results = compare_pairs(itertools.product(funcs, funcs_b))
+        internal = compare_pairs(
+            [(funcs[i], funcs[j]) for i, j in itertools.combinations(range(len(funcs)), 2)]
+            + [(funcs_b[i], funcs_b[j]) for i, j in itertools.combinations(range(len(funcs_b)), 2)]
         )
-        for a, b in identical[:10]:
-            print(f"  identical: {a} <-> {b}")
-        print(
-            f"ceiling: {len(near)}/{n_cross} further pairs score >= {COLLISION_SIM} "
-            f"without being identical"
-        )
-        for sim, a, b in sorted(near, reverse=True)[:10]:
-            print(f"  {sim:.4f}: {a} <-> {b}")
+        results = cross_results + internal
+        print(f"A x B pairs: {len(cross_results)}   A/B-internal pairs: {len(internal)}")
 
-        decomp.closeProgram()
-        decomp.dispose()
+    # Distinct source functions that share a feature vector are indistinguishable
+    # to ANY weighting scheme -- an information limit of the signature, not an
+    # algorithm error. Measuring this ceiling first keeps it from being counted
+    # as a false positive later.
+    ceiling_funcs = funcs + (funcs_b or [])
+    identical = []
+    near = []
+    for (name_a, _, ours_a), (name_b, _, ours_b) in itertools.combinations(ceiling_funcs, 2):
+        if ours_a == ours_b:
+            identical.append((name_a, name_b))
+        else:
+            sim, _ = table.compare(ours_a, ours_b)
+            if sim >= COLLISION_SIM:
+                near.append((sim, name_a, name_b))
+    n_cross = len(ceiling_funcs) * (len(ceiling_funcs) - 1) // 2
+    print(
+        f"\nceiling: {len(identical)}/{n_cross} distinct-function pairs have "
+        f"IDENTICAL feature vectors"
+    )
+    for a, b in identical[:10]:
+        print(f"  identical: {a} <-> {b}")
+    print(
+        f"ceiling: {len(near)}/{n_cross} further pairs score >= {COLLISION_SIM} "
+        f"without being identical"
+    )
+    for sim, a, b in sorted(near, reverse=True)[:10]:
+        print(f"  {sim:.4f}: {a} <-> {b}")
 
-    print(f"pairs compared: {len(results)}")
+    print(f"\npairs compared: {len(results)}")
+    print_buckets(results)
+    if cross_results is not None:
+        print_name_summary(cross_results)
+
     max_sim = max(r[0] for r in results)
     max_sig = max(r[1] for r in results)
     print(f"max |sim diff| = {max_sim:.3e}   (tol {SIM_TOL:.0e})")

--- a/scripts/bench/recall.py
+++ b/scripts/bench/recall.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Does weighting find functions back better than unweighted?
+
+Retrieval-first, because that is how the tool is actually used: for each
+function in binary A, rank every function in binary B and ask where its true
+counterpart landed. Threshold-free, so no tuning is involved.
+
+Ground truth is the symbol name. Two builds of one source from different
+compilers/architectures share function names, so a same-name pair is a known
+match and a different-name pair is a known non-match -- no judgement call.
+
+IMPORTANT: with a single project, every non-match is two functions from the
+same program, so the false-positive numbers here are a floor, not an estimate.
+A trustworthy FPR needs a second, unrelated program built with the same
+toolchains. The `identical vectors` line reports the ceiling: distinct
+functions that share a feature vector cannot be separated by ANY weighting
+scheme, so they are an information limit of the signature, not an error.
+
+Vectors come from either:
+  --vectors FILE   JSON from `oracle_compare.py --dump-vectors` ({"A": ..., "B": ...})
+  --collection C   read {coll}:func:*:vec:tf straight from kvrocks, grouping by
+                   file md5 and labelling from each function's :meta
+
+Usage:
+    scripts/bench/recall.py --vectors vecs.json
+    scripts/bench/recall.py --collection wtest --md5 <a> --md5 <b>
+"""
+
+import argparse
+import json
+import math
+import os
+import statistics
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from bsimvis.app.services import bsim_profiles, bsim_weights  # noqa: E402
+
+MIN_FEATURES = 10
+
+
+# --- scorers ----------------------------------------------------------------
+
+
+def prep_unweighted(v):
+    return {h: int(t) for h, t in v.items()}, math.sqrt(sum(int(t) ** 2 for t in v.values()))
+
+
+def score_unweighted(pa, pb):
+    a, na = pa
+    b, nb = pb
+    small, large = (a, b) if len(a) <= len(b) else (b, a)
+    dot = sum(x * large[h] for h, x in small.items() if h in large)
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def score_jaccard(pa, pb):
+    a, _ = pa
+    b, _ = pb
+    small, large = (a, b) if len(a) <= len(b) else (b, a)
+    inter = sum(min(x, large[h]) for h, x in small.items() if h in large)
+    union = sum(a.values()) + sum(b.values()) - inter
+    return inter / union if union else 0.0
+
+
+def prep_weighted(v, table):
+    """int-keyed tf + this function's own coefficients, length and hashcount.
+
+    Per-function work, done once -- see scripts/bench/scoring_cost.py for why
+    doing it inside the pair loop badly overstates the weighted cost.
+    """
+    tf = {int(h, 16): int(t) for h, t in v.items()}
+    co = {h: table.idfweight[table.lookup.get(h, 0)] * table.tfweight[min(t, 64) - 1]
+          for h, t in tf.items()}
+    return tf, co, math.sqrt(sum(c * c for c in co.values())), sum(tf.values())
+
+
+def score_weighted(pa, pb, table, want_sig=False):
+    tfa, coa, la, hca = pa
+    tfb, cob, lb, hcb = pb
+    if len(tfa) <= len(tfb):
+        s_tf, s_co, l_tf, l_co = tfa, coa, tfb, cob
+    else:
+        s_tf, s_co, l_tf, l_co = tfb, cob, tfa, coa
+    dot = 0.0
+    inter = 0
+    for h, x in s_tf.items():
+        y = l_tf.get(h)
+        if y is None:
+            continue
+        # min-tf rule: the smaller side's own precomputed coefficient is correct.
+        dot += (s_co[h] if x <= y else l_co[h]) ** 2
+        inter += x if x < y else y
+    sim = dot / (la * lb) if la > 0 and lb > 0 else 0.0
+    if sim > 1.0:
+        sim = 1.0
+    if not want_sig:
+        return sim
+    lo, hi = (hca, hcb) if hca < hcb else (hcb, hca)
+    sig = (dot - (lo - inter) * (table.probflip0 + table.probflip1 / hi)
+           - (hi - lo) * (table.probdiff0 + table.probdiff1 / hi) + table.addend) if hi else table.addend
+    return sim, sig
+
+
+# --- loading ----------------------------------------------------------------
+
+
+def load_from_json(path):
+    d = json.load(open(path))
+    return d["A"], d.get("B") or {}
+
+
+def load_from_collection(collection, md5s):
+    from bsimvis.app.services.redis_client import get_redis
+
+    r = get_redis()
+    groups = {}
+    for key in r.scan_iter(match=f"{collection}:func:*:meta", count=5000):
+        key = key.decode()
+        base = key[: -len(":meta")]
+        parts = base.split(":")
+        md5 = parts[2]
+        if md5s and md5 not in md5s:
+            continue
+        try:
+            meta = json.loads(r.get(key))
+        except Exception:
+            continue
+        if not isinstance(meta, dict):
+            continue
+        name = meta.get("function_name")
+        vec = r.zrange(f"{base}:vec:tf", 0, -1, withscores=True)
+        if not name or not vec:
+            continue
+        v = {h.decode() if isinstance(h, bytes) else h: int(t) for h, t in vec}
+        if len(v) < MIN_FEATURES:
+            continue
+        # Keep the largest instance when a name repeats within one binary.
+        g = groups.setdefault(md5, {})
+        if name not in g or len(v) > len(g[name]):
+            g[name] = v
+    if len(groups) < 2:
+        sys.exit(f"need functions from 2 binaries, found {len(groups)}")
+    (_, a), (_, b) = sorted(groups.items())[:2]
+    return a, b
+
+
+# --- evaluation -------------------------------------------------------------
+
+
+def evaluate(name, A, B, prep, score):
+    """Rank all of B for each function of A; report where the true match landed."""
+    pa = {n: prep(v) for n, v in A.items()}
+    pb = {n: prep(v) for n, v in B.items()}
+    shared = [n for n in pa if n in pb]
+
+    ranks, true_scores, false_scores = [], [], []
+    for n in shared:
+        scored = sorted(((score(pa[n], pb[m]), m) for m in pb), reverse=True)
+        for i, (s, m) in enumerate(scored, 1):
+            if m == n:
+                ranks.append(i)
+                true_scores.append(s)
+                break
+        false_scores += [s for s, m in scored if m != n]
+
+    n = len(ranks)
+    if not n:
+        return None
+    return {
+        "algo": name,
+        "queries": n,
+        "recall@1": sum(r == 1 for r in ranks) / n,
+        "recall@5": sum(r <= 5 for r in ranks) / n,
+        "mrr": sum(1 / r for r in ranks) / n,
+        "true_median": statistics.median(true_scores),
+        "true_min": min(true_scores),
+        "false_median": statistics.median(false_scores),
+        "false_max": max(false_scores),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vectors", help="JSON from oracle_compare.py --dump-vectors")
+    ap.add_argument("--collection", help="read vectors from kvrocks instead")
+    ap.add_argument("--md5", action="append", default=[], help="restrict to these binaries")
+    ap.add_argument("--profile", default=None, help="BSim weights profile")
+    args = ap.parse_args()
+
+    if args.vectors:
+        A, B = load_from_json(args.vectors)
+    elif args.collection:
+        A, B = load_from_collection(args.collection, set(args.md5))
+    else:
+        ap.error("need --vectors or --collection")
+
+    table = bsim_weights.load(bsim_profiles.get_profile(args.profile).weights_path)
+    print(f"binary A: {len(A)} functions   binary B: {len(B)} functions")
+    shared = set(A) & set(B)
+    print(f"shared names (ground-truth matches): {len(shared)}")
+    if not shared:
+        sys.exit("no shared function names -- are these builds of the same source?")
+
+    rows = [
+        evaluate("jaccard", A, B, prep_unweighted, score_jaccard),
+        evaluate("unweighted_cosine", A, B, prep_unweighted, score_unweighted),
+        evaluate("weighted_cosine", A, B,
+                 lambda v: prep_weighted(v, table),
+                 lambda x, y: score_weighted(x, y, table)),
+    ]
+    rows = [r for r in rows if r]
+
+    print(f"\n{'algo':<20}{'recall@1':>10}{'recall@5':>10}{'MRR':>8}"
+          f"{'true med':>10}{'true min':>10}{'false med':>11}{'false max':>11}")
+    for r in rows:
+        print(f"{r['algo']:<20}{r['recall@1']:>9.1%}{r['recall@5']:>10.1%}{r['mrr']:>8.3f}"
+              f"{r['true_median']:>10.4f}{r['true_min']:>10.4f}"
+              f"{r['false_median']:>11.4f}{r['false_max']:>11.4f}")
+
+    best = max(rows, key=lambda r: r["recall@1"])
+    print(f"\nbest recall@1: {best['algo']} ({best['recall@1']:.1%})")
+
+    # Ceiling: pairs no weighting scheme could ever separate.
+    ident = 0
+    for n, v in A.items():
+        for m, w in B.items():
+            if n != m and v == w:
+                ident += 1
+    print(f"ceiling: {ident} distinct-name pairs have IDENTICAL feature vectors "
+          f"(unfixable by any weighting)")
+    print("NOTE: single project -> false-score columns are a floor, not an FPR. "
+          "A real FPR needs a second unrelated program.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench/scoring_cost.py
+++ b/scripts/bench/scoring_cost.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Cost of weighted vs unweighted scoring in the O(n^2) build-sim inner loop.
+
+Only the per-pair work is timed. All per-function work (norms, lengths,
+coefficient maps) is precomputed, because that is O(n) index-time work and
+charging it to the pair loop overstates the weighted penalty several times over.
+
+Also demonstrates the key property that makes weighting affordable: the min-tf
+rule needs NO per-pair coefficient computation. When tf_a == tf_b each side's own
+precomputed coefficient is already correct; when they differ the rule wants the
+smaller side's coefficient, which is exactly that side's precomputed value. The
+tail of this script asserts that against the reference compare().
+
+Needs vectors dumped by:
+    scripts/bench/oracle_compare.py <bin> --binary-b <bin> --dump-vectors vecs.json
+
+Usage:
+    VECS=vecs.json .venv/bin/python scripts/bench/scoring_cost.py
+"""
+import json, math, os, sys, time, random
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from bsimvis.app.services.bsim_weights import WeightTable
+
+W = os.environ.get("WEIGHTS", os.path.join(
+    os.environ.get("GHIDRA_INSTALL_DIR", "bin/ghidra_12.1_PUBLIC"),
+    "Ghidra/Features/BSim/data/lshweights_nosize.xml"))
+t = WeightTable.from_file(W)
+d = json.load(open(os.environ.get("VECS", "vecs.json")))
+A, B = list(d["A"].values()), list(d["B"].values())
+
+def scale(vecs, factor, seed):
+    rnd = random.Random(seed); out=[]
+    for v in vecs:
+        nv=dict(v)
+        for _ in range(len(v)*(factor-1)):
+            nv[f"{rnd.getrandbits(32):08x}"] = 1 if rnd.random()<0.85 else 2
+        out.append(nv)
+    return out
+
+# ---- per-function precomputation (INDEX TIME, not counted) ----------------
+def prep_unweighted(v):
+    return v, math.sqrt(sum(x*x for x in v.values()))
+
+def prep_weighted(v):
+    """int-keyed tf + coeff at this function's own tf, plus length & hashcount."""
+    tf = {int(h,16): int(x) for h,x in v.items()}
+    co = {h: t.idfweight[t.lookup.get(h,0)] * t.tfweight[min(x,64)-1] for h,x in tf.items()}
+    length = math.sqrt(sum(c*c for c in co.values()))
+    return tf, co, length, sum(tf.values())
+
+# ---- O(n^2) inner loops ---------------------------------------------------
+def pair_unweighted(pa, pb):
+    a,na = pa; b,nb = pb
+    small,large = (a,b) if len(a)<=len(b) else (b,a)
+    dot = 0.0
+    for h,x in small.items():
+        y = large.get(h)
+        if y is not None: dot += x*y
+    return dot/(na*nb) if na and nb else 0.0
+
+def pair_weighted(pa, pb, want_sig):
+    tfa,coa,la,hca = pa; tfb,cob,lb,hcb = pb
+    if len(tfa) <= len(tfb): s_tf,s_co,l_tf,l_co = tfa,coa,tfb,cob
+    else:                    s_tf,s_co,l_tf,l_co = tfb,cob,tfa,coa
+    dot = 0.0; inter = 0
+    for h,x in s_tf.items():
+        y = l_tf.get(h)
+        if y is None: continue
+        if x == y:                 # overwhelmingly common: coeff already correct
+            w = s_co[h]
+        else:                      # min-tf rule needs the smaller side's coeff
+            w = s_co[h] if x < y else l_co[h]
+        dot += w*w
+        inter += x if x < y else y
+    sim = dot/(la*lb) if la>0 and lb>0 else 0.0
+    if sim > 1.0: sim = 1.0
+    if not want_sig: return sim
+    lo,hi = (hca,hcb) if hca<hcb else (hcb,hca)
+    sig = (dot - (lo-inter)*(t.probflip0 + t.probflip1/hi)
+               - (hi-lo)*(t.probdiff0 + t.probdiff1/hi) + t.addend) if hi else t.addend
+    return sim, sig
+
+def bench(fn, pairs, reps=5):
+    best=float("inf")
+    for _ in range(reps):
+        t0=time.perf_counter()
+        for pa,pb in pairs: fn(pa,pb)
+        best=min(best,time.perf_counter()-t0)
+    return best/len(pairs)*1e6
+
+for factor,label in ((1,"real (~20 feats)"),(6,"~120 feats"),(20,"~400 feats")):
+    av,bv = (A,B) if factor==1 else (scale(A,factor,1),scale(B,factor,2))
+    ua=[prep_unweighted(v) for v in av]; ub=[prep_unweighted(v) for v in bv]
+    wa=[prep_weighted(v) for v in av];   wb=[prep_weighted(v) for v in bv]
+    up=[(x,y) for x in ua for y in ub];  wp=[(x,y) for x in wa for y in wb]
+    u  = bench(pair_unweighted, up)
+    ws = bench(lambda a,b: pair_weighted(a,b,False), wp)
+    wf = bench(lambda a,b: pair_weighted(a,b,True),  wp)
+    print(f"\n{label}  ({len(up)} pairs, all per-function work precomputed)")
+    print(f"  unweighted_cosine            : {u:7.2f} us/pair")
+    print(f"  weighted, sim only           : {ws:7.2f} us/pair  ({ws/u:4.2f}x unweighted)")
+    print(f"  weighted, sim + significance : {wf:7.2f} us/pair  ({wf/u:4.2f}x unweighted, "
+          f"{100*(wf-ws)/ws:+.1f}% over sim-only)")
+
+# --- correctness: optimized loop must equal the reference compare() ---------
+worst_sim = worst_sig = 0.0
+for x in A:
+    for y in B:
+        rs, rg = t.compare(x, y)
+        os_, og = pair_weighted(prep_weighted(x), prep_weighted(y), True)
+        worst_sim = max(worst_sim, abs(rs-os_)); worst_sig = max(worst_sig, abs(rg-og))
+# force the min-tf branch: same hashes, deliberately differing tf
+import copy
+a = {h: 1 for h in list(A[0])[:15]}
+b = {h: (7 if i%2 else 1) for i,h in enumerate(list(A[0])[:15])}
+rs, rg = t.compare(a,b); os_, og = pair_weighted(prep_weighted(a), prep_weighted(b), True)
+print(f"\ncorrectness vs reference compare(): max|dsim|={worst_sim:.3e} max|dsig|={worst_sig:.3e}")
+print(f"  min-tf branch (differing tf): dsim={abs(rs-os_):.3e} dsig={abs(rg-og):.3e} "
+      f"(sim {rs:.6f}, sig {rg:.4f})")

--- a/scripts/wt-test.sh
+++ b/scripts/wt-test.sh
@@ -19,6 +19,7 @@ APP_PORT=${APP_PORT:-5100}
 # test_pools.py was absorbed into test_api_endpoints.py (step 3d).
 export API_URL="http://localhost:$APP_PORT"   # test_api_endpoints reads this
 rc=0
+echo "=== test_bsim_weights.py ==="; uv run python test_bsim_weights.py || rc=1
 echo "=== test_api_endpoints.py ==="; uv run python test_api_endpoints.py "$@" || rc=1
 
 "$WT_ROOT/scripts/wt-teardown.sh"

--- a/test_api_endpoints.py
+++ b/test_api_endpoints.py
@@ -712,6 +712,86 @@ def run_all_tests():
             "GET", "/api/similarity", params={"id1": func_id1, "id2": func_id2}
         )
 
+        # weighted_cosine is opt-in via ?algo= and is the only algorithm that
+        # also reports a significance value.
+        weighted = test_endpoint(
+            "GET",
+            "/api/similarity",
+            params={
+                "id1": func_id1,
+                "id2": func_id2,
+                "algo": "unweighted_cosine,weighted_cosine",
+            },
+            label="GET /api/similarity?algo=weighted_cosine",
+        )
+        if weighted:
+            scores = weighted.get("scores", {})
+            sig = weighted.get("significance", {})
+            check(
+                "weighted_cosine score returned",
+                isinstance(scores.get("weighted_cosine"), (int, float)),
+                f"scores={scores}",
+            )
+            check(
+                "weighted_cosine reports significance",
+                "weighted_cosine" in sig,
+                f"significance={sig}",
+            )
+            check(
+                "unweighted_cosine carries no significance",
+                "unweighted_cosine" not in sig,
+                f"significance={sig}",
+            )
+
+        # A profile-qualified algorithm must resolve to the same score.
+        qualified = test_endpoint(
+            "GET",
+            "/api/similarity",
+            params={
+                "id1": func_id1,
+                "id2": func_id2,
+                "algo": "weighted_cosine:nosize",
+            },
+            label="GET /api/similarity?algo=weighted_cosine:nosize",
+        )
+        if qualified and weighted:
+            a = (weighted.get("scores") or {}).get("weighted_cosine")
+            b = (qualified.get("scores") or {}).get("weighted_cosine:nosize")
+            check(
+                "profile-qualified weighted score matches the default profile",
+                a is not None and b is not None and abs(a - b) < 1e-12,
+                f"{a} vs {b}",
+            )
+
+        # An unknown profile must report an error, not 500 or a silent null.
+        bad = test_endpoint(
+            "GET",
+            "/api/similarity",
+            params={
+                "id1": func_id1,
+                "id2": func_id2,
+                "algo": "weighted_cosine:no_such_profile",
+            },
+            label="GET /api/similarity?algo=weighted_cosine:<unknown>",
+        )
+        if bad:
+            check(
+                "unknown weights profile reported as an error",
+                "Unknown BSim profile"
+                in str((bad.get("errors") or {}).get("weighted_cosine:no_such_profile")),
+                f"errors={bad.get('errors')}",
+            )
+
+    # The build path cannot compute weighted_cosine; it must refuse rather than
+    # emit unfiltered pairs.
+    test_endpoint(
+        "POST",
+        "/api/similarity/build",
+        data={"collection": COLLECTION, "all": True, "algo": "weighted_cosine"},
+        expected_ok=False,
+        label="POST /api/similarity/build?algo=weighted_cosine (expect 400)",
+    )
+
     # ── Tags ───────────────────────────────────────────────────────────────
     print(_color("\n  [Tags]", BOLD))
     test_endpoint("GET", "/api/tags", params={"collection": COLLECTION})

--- a/test_bsim_weights.py
+++ b/test_bsim_weights.py
@@ -280,6 +280,32 @@ def test_signature_settings_falls_back_when_table_is_missing():
     assert settings == 0x4D
 
 
+# --- build-path guard -------------------------------------------------------
+
+
+def test_build_path_rejects_weighted_cosine():
+    """The build path branches only on jaccard/unweighted_cosine.
+
+    Letting weighted_cosine through would not raise -- it would fall past every
+    branch and emit unfiltered, meaningless pairs. Fail loudly instead.
+    """
+    from bsimvis.app.services.similarity_service import (
+        assert_buildable_algo,
+        BUILDABLE_ALGOS,
+    )
+
+    for algo in BUILDABLE_ALGOS:
+        assert_buildable_algo(algo)
+    assert_buildable_algo(None)  # None means "use the configured default"
+
+    msg = _raises(ValueError, assert_buildable_algo, "weighted_cosine")
+    assert "not supported by the similarity build path" in msg
+    # Profile-qualified form must be rejected too.
+    msg = _raises(ValueError, assert_buildable_algo, "weighted_cosine:nosize")
+    assert "not supported by the similarity build path" in msg
+    _raises(ValueError, assert_buildable_algo, "nonsense_algo")
+
+
 if __name__ == "__main__":
     passed = skipped = 0
     for name, fn in sorted(globals().items()):

--- a/test_bsim_weights.py
+++ b/test_bsim_weights.py
@@ -1,0 +1,296 @@
+"""BSim signature-settings profiles and feature weighting.
+
+The weighting math is transcribed from Ghidra's reference C implementation
+(Features/BSim/src/lshvector/c/weights.c); these tests pin the parts that are
+easy to get subtly wrong and that would otherwise fail silently -- above all the
+min-tf dot product rule, which agrees with the naive one on almost every pair.
+
+Tests needing Ghidra's shipped weight tables are skipped when no install is
+present (set GHIDRA_INSTALL_DIR, or have bin/ghidra_*).
+"""
+
+import math
+import os
+from pathlib import Path
+
+from bsimvis.app.services import bsim_profiles, bsim_weights
+from bsimvis.app.services.bsim_profiles import ProfileError
+
+EPS = 1e-12
+
+
+class Skip(Exception):
+    """Raised by a test that cannot run in this environment."""
+
+
+def _shipped_table():
+    """Path to Ghidra's lshweights_nosize.xml, or None if no install is present."""
+    root = os.environ.get("GHIDRA_INSTALL_DIR")
+    candidates = [Path(root)] if root else []
+    candidates += sorted(Path("bin").glob("ghidra_*"), reverse=True)
+    for base in candidates:
+        p = base / "Ghidra" / "Features" / "BSim" / "data" / "lshweights_nosize.xml"
+        if p.is_file():
+            return p
+    return None
+
+
+def _table():
+    path = _shipped_table()
+    if path is None:
+        raise Skip("no Ghidra install with BSim weight tables")
+    return bsim_weights.WeightTable.from_file(path)
+
+
+def _raises(exc, fn, *args, **kwargs):
+    try:
+        fn(*args, **kwargs)
+    except exc as e:
+        return str(e)
+    raise AssertionError(f"expected {exc.__name__}")
+
+
+# --- module self-checks -----------------------------------------------------
+
+
+def test_module_self_checks():
+    bsim_profiles.demo()
+    bsim_weights.demo()
+
+
+# --- signature settings mask ------------------------------------------------
+
+
+def test_mask_validation_mirrors_ghidra():
+    assert bsim_profiles.test_settings(0x4D)
+    assert bsim_profiles.test_settings(0x49)
+    # Ghidra's testSettings rejects zero outright.
+    assert not bsim_profiles.test_settings(0)
+    # Nothing outside 0x1CD may be set.
+    assert not bsim_profiles.test_settings(0x1CD | 0x200)
+    assert not bsim_profiles.test_settings(0x2)  # bit 1 is not a legal flag position
+    # Bit 0 is called a check bit, but testSettings only *permits* it -- it does
+    # not require it, so 0x4C (0x4D without bit 0) is a legal mask.
+    assert bsim_profiles.test_settings(0x4C)
+    assert bsim_profiles.VALID_SETTINGS_MASK == 0x1CD
+
+
+def test_0x4d_decodes_to_the_nosize_configuration():
+    assert bsim_profiles.decode_settings(0x4D) == [
+        "SIG_COLLAPSE_SIZE",
+        "SIG_COLLAPSE_INDNOISE",
+        "SIG_DONOTUSE_CONST",
+    ]
+    # 0x49 is the sized configuration: the same minus SIG_COLLAPSE_SIZE.
+    assert bsim_profiles.decode_settings(0x49) == [
+        "SIG_COLLAPSE_INDNOISE",
+        "SIG_DONOTUSE_CONST",
+    ]
+    assert 0x4D >> 2 == 0x13
+
+
+def test_decode_rejects_illegal_mask():
+    _raises(ProfileError, bsim_profiles.decode_settings, 0)
+
+
+def test_algo_namespacing_roundtrip():
+    assert bsim_profiles.parse_algo("weighted_cosine:nosize") == (
+        "weighted_cosine",
+        "nosize",
+    )
+    assert bsim_profiles.parse_algo("jaccard") == ("jaccard", None)
+    assert (
+        bsim_profiles.qualified_algo("weighted_cosine", "custom")
+        == "weighted_cosine:custom"
+    )
+
+
+# --- weight table parsing / scoring ----------------------------------------
+
+
+def test_shipped_table_parses_to_expected_shape():
+    t = _table()
+    assert len(t.idfweight) == bsim_weights.IDF_SIZE
+    assert len(t.tfweight) == bsim_weights.TF_SIZE
+    assert len(t.lookup) == 1000
+    assert abs(t.scale - 1.55369941) < 1e-9
+    assert abs(t.addend - 6.00980084) < 1e-9
+
+
+def test_unknown_hash_gets_maximum_weight():
+    """The central risk of adopting Ghidra's table on a non-x86 corpus.
+
+    A hash missing from the 1000-entry lookup resolves to index 0, the LARGEST
+    weight -- so unfamiliar boilerplate is treated as maximally rare.
+    """
+    t = _table()
+    absent = 0xFFFFFFFF
+    while absent in t.lookup:
+        absent -= 1
+    assert t.coeff(absent, 1) == t.idfweight[0] == max(t.idfweight)
+    known = max(t.lookup, key=lambda h: t.lookup[h])
+    assert t.coeff(known, 1) < t.coeff(absent, 1)
+
+
+def test_identical_and_disjoint_vectors():
+    t = _table()
+    v = {"aabb": 2, "ccdd": 1, "eeff": 3}
+    sim, _ = t.compare(v, v)
+    assert abs(sim - 1.0) < EPS
+    # Threshold logic and ZSET scores assume a closed [0, 1].
+    assert sim <= 1.0
+    assert t.compare({"aabb": 1}, {"ccdd": 1})[0] == 0.0
+
+
+def test_dot_product_uses_smaller_tf_side_not_the_product():
+    """weights.c:428-437 contributes min_side_coeff**2, NOT coeff_a * coeff_b.
+
+    The two agree whenever tf_a == tf_b, so a wrong implementation passes every
+    equal-tf test and only diverges on repeated features.
+    """
+    t = _table()
+    a, b = {"aabb": 1}, {"aabb": 9}
+    sim, _ = t.compare(a, b)
+
+    len_a = t.stats(a)[0]
+    len_b = t.stats(b)[0]
+    w_small = t.coeff("aabb", 1)
+    assert abs(sim - (w_small * w_small) / (len_a * len_b)) < EPS
+
+    naive = t.coeff("aabb", 1) * t.coeff("aabb", 9) / (len_a * len_b)
+    assert abs(sim - naive) > 1e-9
+
+
+def test_tf_curve_is_applied_and_clamped():
+    t = _table()
+    assert t.coeff("aabb", 1) == t.idfweight[t.lookup.get(0xAABB, 0)]
+    assert t.coeff("aabb", 999) == t.coeff("aabb", bsim_weights.TF_SIZE)
+    # tf below 1 is nonsensical; treat it as a single occurrence rather than
+    # indexing tfweight[-1] and silently picking the largest tf weight.
+    assert t.coeff("aabb", 0) == t.coeff("aabb", 1)
+
+
+def test_similarity_ignores_scale_but_significance_does_not():
+    """sqrt(scale) multiplies every coefficient and cancels in the cosine."""
+    base = _table()
+    rescaled = bsim_weights.WeightTable(
+        idf=[v / math.sqrt(base.scale) for v in base.idfweight],
+        tf=base.tfweight,
+        scale=base.scale * 4.0,
+        addend=base.addend,
+        weightnorm=base.weightnorm,
+        probflip=(0.0, 0.0),
+        probdiff=(0.0, 0.0),
+        lookup=base.lookup,
+    )
+    a, b = {"aabb": 2, "ccdd": 1}, {"aabb": 1, "eeff": 4}
+    assert abs(base.compare(a, b)[0] - rescaled.compare(a, b)[0]) < EPS
+
+
+def test_significance_suppresses_boilerplate_only_matches():
+    """A high cosine over few features must not carry high significance.
+
+    This is the property that actually addresses #30: boilerplate-only matches
+    self-suppress even when their similarity looks convincing.
+    """
+    t = _table()
+    tiny_sim, tiny_sig = t.compare({"aabb": 1}, {"aabb": 1})
+
+    rich = {f"{0xAA00 + i:04x}": 1 for i in range(40)}
+    rich_sim, rich_sig = t.compare(rich, rich)
+
+    assert abs(tiny_sim - rich_sim) < EPS  # both are perfect matches
+    assert rich_sig > tiny_sig  # but the substantial one carries far more weight
+
+
+def test_length_mismatch_penalizes_significance():
+    t = _table()
+    a = {"aabb": 1, "ccdd": 1}
+    matched = t.compare(a, a)[1]
+    padded = t.compare(a, dict(a, **{f"{0xBB00 + i:04x}": 1 for i in range(30)}))[1]
+    assert padded < matched
+
+
+def test_stats_can_be_precomputed():
+    """Cached (length, hashcount) must give the same answer as recomputing."""
+    t = _table()
+    a, b = {"aabb": 2, "ccdd": 1}, {"aabb": 1, "eeff": 4}
+    assert t.compare(a, b) == t.compare(a, b, stats_a=t.stats(a), stats_b=t.stats(b))
+
+
+# --- profile resolution -----------------------------------------------------
+
+
+def test_default_profile_pairs_0x4d_with_the_nosize_table():
+    if _shipped_table() is None:
+        raise Skip("no Ghidra install")
+    p = bsim_profiles.get_profile("nosize")
+    assert p.settings == 0x4D
+    assert p.weights_path.name == "lshweights_nosize.xml"
+
+
+def _with_profiles(profiles, fn):
+    """Swap the configured profile table for the duration of `fn`."""
+    original = bsim_profiles._configured_profiles
+    bsim_profiles._configured_profiles = lambda: profiles
+    try:
+        return fn()
+    finally:
+        bsim_profiles._configured_profiles = original
+
+
+def test_mismatched_weights_table_is_refused():
+    """A table built for other signature settings must fail loudly, not score."""
+    path = _shipped_table()
+    if path is None:
+        raise Skip("no Ghidra install")
+    sized = path.parent / "lshweights_32.xml"
+    if not sized.is_file():
+        raise Skip("lshweights_32.xml absent")
+
+    msg = _with_profiles(
+        {"bad": {"settings": 0x4D, "weights": str(sized)}},
+        lambda: _raises(ProfileError, bsim_profiles.get_profile, "bad"),
+    )
+    assert "0x49" in msg and "0x4d" in msg
+
+
+def test_unknown_profile_name_raises():
+    msg = _raises(ProfileError, bsim_profiles.get_profile, "no_such_profile_xyz")
+    assert "Unknown BSim profile" in msg
+
+
+def test_invalid_mask_in_profile_raises():
+    msg = _with_profiles(
+        {"bad": {"settings": 0x2, "weights": "whatever.xml"}},
+        lambda: _raises(ProfileError, bsim_profiles.get_profile, "bad"),
+    )
+    assert "invalid signature settings" in msg
+
+
+def test_signature_settings_falls_back_when_table_is_missing():
+    """Feature extraction must not fail because a weights table is absent.
+
+    Ingest hosts need the mask but never the weights.
+    """
+    settings = _with_profiles(
+        {"nosize": {"settings": 0x4D, "weights": "/nonexistent/table.xml"}},
+        bsim_profiles.get_signature_settings,
+    )
+    assert settings == 0x4D
+
+
+if __name__ == "__main__":
+    passed = skipped = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_"):
+            continue
+        try:
+            fn()
+        except Skip as e:
+            print(f"skip  {name}  ({e})")
+            skipped += 1
+        else:
+            print(f"ok    {name}")
+            passed += 1
+    print(f"all passed ({passed} run, {skipped} skipped)")


### PR DESCRIPTION
Addresses part of #30. Stacks on `dev`.

## What this does

**1. `0x4D` is no longer hardcoded or undocumented.**
Signature settings and the weight table paired with them are now named profiles in config:

```toml
[bsim]
    profile = "nosize"
    [bsim.profiles.nosize]
        settings = 0x4D
        weights = "lshweights_nosize.xml"
```

The mask alone *cannot* identify a weights file — four of Ghidra's five tables declare `0x49`, only `lshweights_nosize.xml` declares `0x4d`. Ghidra resolves this through db template configs (`medium_nosize.xml`); we make the pairing explicit. A table declaring a different mask than its profile is refused rather than silently scored with.

`doc/bsim_signature_settings.md` documents what the mask means, decoded from Ghidra source: bit 0 is a check bit, flags start at bit 2 (`sigmods = setting >> 2`), so `0x4D >> 2 = 0x13` = `SIG_COLLAPSE_SIZE | SIG_COLLAPSE_INDNOISE | SIG_DONOTUSE_CONST` — the *nosize* configuration.

**2. Per-collection guard.** The mask is recorded on first ingest and scoring refuses to compare vectors extracted under different masks. Hashes from different masks aren't comparable; nothing previously stopped that from producing a meaningless number. Collections predating the field are treated as compatible.

**3. `weighted_cosine` + significance**, transcribed from Ghidra's reference implementation (the PostgreSQL extension in `Features/BSim/src/lshvector/c/weights.c`) rather than reconstructed from the XML shape.

## Two details worth reviewer attention

- **`<idflookup>`'s `count` is an index into the idf curve, not a document frequency.** A hash absent from the 1000-entry table resolves to index 0 — the **largest** weight. Ghidra's corpus is predominantly x86 C/C++; ours is Go on MIPS/ARM/SH4/m68k. So adopting the shipped table could amplify exactly the boilerplate it's meant to suppress. **This is why nothing changes the default yet.**
- **The dot product uses the smaller-tf side's coefficient, squared** — not `coeff_a * coeff_b` (`weights.c:428-437`). Because `coeff` already folds in the tf curve, this counts only shared multiplicity. The two rules agree whenever `tf_a == tf_b`, i.e. nearly always, so a naive implementation looks right until it isn't. Pinned by `test_dot_product_uses_smaller_tf_side_not_the_product`.

## No staleness by construction

Weights are static file artifacts, never derived from the live collection. Uploading files changes no existing coefficient and no stored score, so there is no invalidation logic. Changing profile namespaces the algorithm (`weighted_cosine:nosize`) instead of invalidating anything.

## Not in this PR

- **The build path** (`similarity_service.py:322-396`, the inverted-index candidate walk with pruning bounds) is untouched — `weighted_cosine` currently works on the exact-score path. Deliberate: the plan gates that work behind the coverage measurement below, which may say the shipped table is wrong for this corpus.
- **`scripts/bench/idf_coverage.py` has not been run against a real collection** — this worktree has its own empty data dir. Run `scripts/bench/idf_coverage.py <collection>` to get the go/no-go number.
- The labelled-pair benchmark (TPR/FPR, retrieval metrics) and `make_weights.py`.

## Verification

- `test_bsim_weights.py`: 19 tests, all pass. Covers mask validation against Ghidra's `testSettings`, the min-tf rule, scale-invariance of similarity, significance suppressing boilerplate-only matches, and profile/table mismatch refusal.
- `./scripts/wt-test.sh`: **317/317 pass**.
- Still outstanding: the oracle test against Ghidra's own `lshvector_compare` in a BSim/H2 database. Everything else is downstream of that transcription being right, so it should land before any default changes.

One correction made during implementation: `testSettings` only *permits* bit 0, it does not require it (`0x4C` is legal). Doc and tests reflect this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)